### PR TITLE
Some initial text to kick-start the reference architecture doc

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,24 @@
+name: Docs
+on: [push, pull_request, workflow_dispatch]
+permissions:
+    contents: write
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - name: Install dependencies
+        run: |
+          pip install sphinx sphinx_rtd_theme myst-parser
+      - name: Sphinx build
+        run: |
+          sphinx-build doc _build
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: _build/
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ For any questions or concerns, please reach out to SATRE project team member [Ha
 
 We look forward to your participation and contributions to the SATRE project, as we work together to build a standard architecture for Trusted Research Environments in an inclusive and supportive environment!
 
-## readthedocs build
+## Sphinx docs build
 Build the document locally with:
 1. Ensure you have a working Python 3 installation
 2. Install Sphinx: `pip install sphinx myst-parser`

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -1,9 +1,16 @@
-Standard Architecture for Trusted Research Environments
-=======================================================
+Standard Architecture for Trusted Research Environments (TREs)
+==============================================================
 
 Note:
-> This project is under active development.
+> This is a living doccument under active development.
 
 Contents
 --------
+
+TRE features
+------------
+
+Comparisons of existing open-source TREs
+----------------------------------------
+
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -7,8 +7,15 @@ Note:
 Contents
 --------
 
+- {ref}`comparisons`
+- {ref}`features`
+
+(features)=
+
 TRE features
 ------------
+
+(comparisons)=
 
 Comparisons of existing open-source TREs
 ----------------------------------------

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -2,7 +2,7 @@ Standard Architecture for Trusted Research Environments (TREs)
 ==============================================================
 
 Note:
-> This is a living doccument under active development.
+> This is a living document under active development.
 
 Contents
 --------

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -13,4 +13,6 @@ TRE features
 Comparisons of existing open-source TREs
 ----------------------------------------
 
+Note:
+> This section may reference separate paper "Comparing open-source trusted research environments", which evaluates Turing Data Safe Haven, AzureTRE and TREEHOOSE.
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,7 +15,7 @@ Contents
 TRE features
 ------------
 
-- Control over data ingress and egress (including an approval process)
+<!-- - Control over data ingress and egress (including an approval process)
 - MFA on login
 - Environments isolated from one another
 - Ability to forbid incoming/outgoing network connections
@@ -36,7 +36,7 @@ TRE features
 - Collaborative Jupyter notebooks
 - Compute beyond VMs (e.g. clusters, ML workbench, databricks)
 - Ease of deployment (e.g. via Infrastructure as Code)
-- Ease of use by end-users
+- Ease of use by end-users -->
 
 (comparisons)=
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -15,6 +15,29 @@ Contents
 TRE features
 ------------
 
+- Control over data ingress and egress (including an approval process)
+- MFA on login
+- Environments isolated from one another
+- Ability to forbid incoming/outgoing network connections
+- Ability to forbid copy-and-paste
+- Ability to install (some) packages from PyPI/CRAN/others
+- Custom compute image and/or easy to customise default image
+- Logging of user actions inside the TRE
+- Logging of network connection attempts
+- Logging of infrastructure actions
+- Delegation of control to specified user roles (eg. permissions to turn VMs on and off)
+- Automatic updates
+- Anti-virus
+- Automatic backup
+- Ability to add/remove compute as needed
+- Ability to use GPU VMs
+- Git server (eg. GitLab/Gitea)
+- Collaborative document writing (eg. CodiMD)
+- Collaborative Jupyter notebooks
+- Compute beyond VMs (e.g. clusters, ML workbench, databricks)
+- Ease of deployment (e.g. via Infrastructure as Code)
+- Ease of use by end-users
+
 (comparisons)=
 
 Comparisons of existing open-source TREs


### PR DESCRIPTION
This PR intends to create a starting point for work on the reference architecture to build upon - for now probably a bunch of section headers and bullet points

### TODO:

- [ ] Deploy Sphinx to GH pages (see [here](https://coderefinery.github.io/documentation/gh_workflow/#github-pages))
- ~~Add issue creation/discussion process to contributing.md~~
- [ ] Remove the current content for now and keep as a simple page with a title only

### After merge TODOs:
- [ ] Open an issue on section headers to build the document structure
- [ ] Once all the above done, share with WP1 project team for awareness of where the doc is and how to edit


~~Take inspiration for features from TRE comparison paper lead by Turing, the agreed TRE features from the TRE builders survey and [tech spec](https://hackmd.io/t4CvletgTwq7KG3nnLsbtQ?both) hackmd from in-person workshop.~~ It's been decided to work on this a bit later when we have more input material in terms of a TRE comparison paper and more concrete feature list post survey