### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # SATRE Specification Repository: Technical Document for the Standard Architecture for Trusted Research Environments Project
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
-[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
-[![Licence](https://img.shields.io/github/license/sa-tre/satre-specification)](https://github.com/sa-tre/satre-specification/blob/main/LICENSE.md)
-[![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue)](https://github.com/sa-tre/satre-specification/blob/main/CODE_OF_CONDUCT.md)
-[![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
+[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack&style=flat-square)](https://ukrse.slack.com/archives/rse-tre-wg)
+[![Licence](https://img.shields.io/github/license/sa-tre/satre-specification?style=flat-square)](https://github.com/sa-tre/satre-specification/blob/main/LICENSE.md)
+[![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue?style=flat-square)](https://github.com/sa-tre/satre-specification/blob/main/CODE_OF_CONDUCT.md)
+[![Docs](https://img.shields.io/github/actions/workflow/status/sa-tre/satre-specification/documentation.yml?branch=main&style=flat-square)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).
 
@@ -30,7 +30,7 @@ SATRE outputs will include an informed TRE reference technical specification and
 
 ## Community-Driven Approach
 
-[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
+[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack&style=flat-square)](https://ukrse.slack.com/archives/rse-tre-wg)
 
 The SATRE project values the importance of equity, diversity, and inclusion (EDI) in fostering a kind and supportive environment for all participants.
 We are committed to making the project as inclusive as possible and appreciate the unique perspectives and input that each community member brings.

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).
 
-Welcome to the SATRE Specification Repository! 
+Welcome to the SATRE Specification Repository!
 This repository stores the technical documents that outlines a reference architecture for Trusted Research Environments.
 ***By October 2023*** we will aim to have drafted the document with input from members of the Systems Architecture, Research Software Engineering and Cyber Security community, with core support from DARE UK funded project members as part of a collaborative effort between the University of Dundee, Ulster University, UCL, Health Data Research UK, The Alan Turing Institute and Research Data Scotland.
 
 If you have experience designing or using Trusted/Secure Research Environments and want to get involved in developing a reference architecture for UK TREs then please read on to find out how you can contribute.
 
 ## Overview of the SATRE Project
-The need for trusted research environments (TREs) is clear. 
+The need for trusted research environments (TREs) is clear.
 Personal or sensitive data which have been collected for operational, commercial or governmental reasons need to be managed securely and safely for research use in an environment that encourages best practice.
-TREs are designed to enable access to sensitive data only for authorised projects and researchers, whilst minimising risk of data release or exposure. 
+TREs are designed to enable access to sensitive data only for authorised projects and researchers, whilst minimising risk of data release or exposure.
 Influential reports from DARE UK and Health Data Research UK, together with the UK Government Goldacre review and ‘Data Saves Lives’ policy paper, have all highlighted the need for change in how sensitive data are handled.
 
-SATRE will compare openly available UK TREs hosting health, manufacturing, commercial, science and humanities data and bring them into alignment with a standardised TRE reference architecture (or structural template). 
+SATRE will compare openly available UK TREs hosting health, manufacturing, commercial, science and humanities data and bring them into alignment with a standardised TRE reference architecture (or structural template).
 The development teams at the University of Dundee’s Health Informatics Centre and the Alan Turing Institute, fully supported by their infrastructure partners, will lead the reference alignment in collaboration with a consortium of higher education, charity and industry organisations.
 
 The reference architecture and its implementation will be informed and strengthened by a programme of community building and engagement with DARE UK and partner working groups, other stakeholders and inclusive public representation.
@@ -47,15 +47,15 @@ There are a number of ways you can get involved with the SATRE project!
 | Monthly Open Roadmap Review  | During the Thursday Collaboration Cafe, the core funded team will provide updates to the Open Roadmap based on community contributions  | Every 3rd Thursday of the month  |[HackMD link please fill]()|
 
 
-2. **Contribute**: Review open issues, join SATRE meetings, and provide your input on the design, implementation, and best practices for TREs. To contribute to the project, please join discussions on open issues to help guide content for the documentation. 
+2. **Contribute**: Review open issues, join SATRE meetings, and provide your input on the design, implementation, and best practices for TREs. To contribute to the project, please join discussions on open issues to help guide content for the documentation.
 If you have a specific idea or proposal, feel free to open a new issue or start a GitHub Discussions thread.
 Currently we are writing documentation in `.md` files and will decide on a more refined documentation format with the Community.
-3. **Sign up to our contact list**: You can sign up by filling in [this short form](https://forms.office.com/e/FuFyNGx3hw). 
+3. **Sign up to our contact list**: You can sign up by filling in [this short form](https://forms.office.com/e/FuFyNGx3hw).
 Sign up for updates about the project, further invitations to workshops & roundtables, and opportunities for feedback & knowledge sharing :sparkles:
 
 4. **Join the RSE TRE community**: The RSE TRE community was established at RSE Con in September 2022, and brings together those building, using, operating and generally affected by and interested in TREs together to solve common challenges and share knowledge. You can register for the JISC mailing list [by following this link](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1)
 ## Code of Conduct and Inclusivity
-The SATRE project is committed to fostering an inclusive, equitable, and respectful environment for all participants. 
+The SATRE project is committed to fostering an inclusive, equitable, and respectful environment for all participants.
 Please review our [Code of Conduct](CODE_OF_CONDUCT.md) to ensure that your interactions with the community align with our values and expectations.
 We encourage everyone to contribute to creating a kind and supportive atmosphere, appreciating each community member's input.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
+[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
 [![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).
@@ -27,7 +28,7 @@ SATRE outputs will include an informed TRE reference technical specification and
 
 ## Community-Driven Approach
 
-[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com) #rse-tre-wg
+[![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
 
 The SATRE project values the importance of equity, diversity, and inclusion (EDI) in fostering a kind and supportive environment for all participants.
 We are committed to making the project as inclusive as possible and appreciate the unique perspectives and input that each community member brings.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
 [![Licence](https://img.shields.io/github/license/sa-tre/satre-specification)](https://github.com/sa-tre/satre-specification/blob/main/LICENSE.md)
+[![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue)](https://github.com/sa-tre/satre-specification/blob/badges/CODE_OF_CONDUCT.md)
 [![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
 [![Licence](https://img.shields.io/github/license/sa-tre/satre-specification)](https://github.com/sa-tre/satre-specification/blob/main/LICENSE.md)
-[![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue)](https://github.com/sa-tre/satre-specification/blob/badges/CODE_OF_CONDUCT.md)
+[![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue)](https://github.com/sa-tre/satre-specification/blob/main/CODE_OF_CONDUCT.md)
 [![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 [![Slack](https://img.shields.io/badge/Slack-Join%20Our%20Channel-blue?logo=slack)](https://ukrse.slack.com/archives/rse-tre-wg)
+[![Licence](https://img.shields.io/github/license/sa-tre/satre-specification)](https://github.com/sa-tre/satre-specification/blob/main/LICENSE.md)
 [![Docs](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml/badge.svg)](https://github.com/sa-tre/satre-specification/actions/workflows/documentation.yml)
 
 **[The specification is a living document hosted here on our GitHub pages site](https://sa-tre.github.io/satre-specification/)**. It can also be viewed here on GitHub at [docs/source/index.md](docs/source/index.md).


### PR DESCRIPTION
- Add badges for licence, code of conduct, build
- Change link of slack badge to direct to rse-tre-wg channel
- Use a consistent style for all badges