### PR TITLE
added information on satre team contributions on behalf of community

### DIFF
--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -79,7 +79,7 @@ Issue templates have been designed for common issue types to help collect the mo
 It is possible, however, to open a blank issue if none of the templates are suitable.
 
 While we encourage opening issues, we understand that some may be more comfortable contributing ideas in other ways such as through discussions and notes at SATRE Collaboration Cafés.
-The SATRE Team will aim to collate ideas and draft Issues that welcome further discussion and attribute those involved in initial discussions. 
+The SATRE Team will aim to collate ideas and draft issues that welcome further discussion and attribute those involved in initial discussions.
 The SATRE Team will try to capture the ideas as accurately as possible, in good faith, and be guided by the SATRE Community to correct any misconceptions.
 
 When ready, changes will be proposed in pull requests.

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -78,7 +78,7 @@ Issues should be used to discuss ideas, potential changes and to ask questions.
 Issue templates have been designed for common issue types to help collect the most important information and present it in a clear, consistent way.
 It is possible, however, to open a blank issue if none of the templates are suitable.
 
-While we encourage opening Issues, we understand that some may be more comfortable contributing ideas in other ways such as through discussions and notes at SATRE Collaboration Cafés.
+While we encourage opening issues, we understand that some may be more comfortable contributing ideas in other ways such as through discussions and notes at SATRE Collaboration Cafés.
 The SATRE Team will aim to collate ideas and draft Issues that welcome further discussion and attribute those involved in initial discussions. 
 The SATRE Team will try to capture the ideas as accurately as possible, in good faith, and be guided by the SATRE Community to correct any misconceptions.
 

--- a/docs/source/contributing.md
+++ b/docs/source/contributing.md
@@ -78,6 +78,10 @@ Issues should be used to discuss ideas, potential changes and to ask questions.
 Issue templates have been designed for common issue types to help collect the most important information and present it in a clear, consistent way.
 It is possible, however, to open a blank issue if none of the templates are suitable.
 
+While we encourage opening Issues, we understand that some may be more comfortable contributing ideas in other ways such as through discussions and notes at SATRE Collaboration Cafés.
+The SATRE Team will aim to collate ideas and draft Issues that welcome further discussion and attribute those involved in initial discussions. 
+The SATRE Team will try to capture the ideas as accurately as possible, in good faith, and be guided by the SATRE Community to correct any misconceptions.
+
 When ready, changes will be proposed in pull requests.
 Similarly to issues, there is a pull request template.
 This template prompts contributors to include important details which helps explain the contribution and makes triage and review easier.


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [x] This pull request has had the appropriate labels assigned
- [ ] This pull request has been added to the SATRE backlog project board
- [x] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
-->

This PR intended to add information on how SATRE Team members contribute to the specification on behalf of community members i.e. ideas coming from a Collaboration Café. The SATRE team try to represent ideas as accurately as possible and are made in good faith.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
