### PR TITLE
Remove horizontal scrollbar from tables and return to previous format

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,11 +1,10 @@
-{% extends "!layout.html" %}
-{% block footer %} {{ super() }}
+{% extends "!layout.html" %} {% block footer %} {{ super() }}
 
 <style>
-    .wy-table-responsive table td, .wy-table-responsive table th {
+  .wy-table-responsive table td,
+  .wy-table-responsive table th {
     white-space: normal;
-    }
-    
+  }
 </style>
 
 {% endblock %}

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,11 @@
+{% extends "!layout.html" %}
+{% block footer %} {{ super() }}
+
+<style>
+    .wy-table-responsive table td, .wy-table-responsive table th {
+    white-space: normal;
+    }
+    
+</style>
+
+{% endblock %}


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [ ] This pull request has had the appropriate labels assigned
- [ ] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
-->

PR #124 fixed the dropdown menu and search functions of the site, but changed the format of tables to be horizontally scrolling with single-line entries, rather than fitting the text into the width of the page. 

This modifies `layout.html` using a file in the `_templates` directory, changing the `white-wrap` property of the table CSS from the theme default of `nowrap` to `normal`

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

Relates to PR #124 

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
