### PR TITLE
fix link and add venv to gitignore for docs builders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ Thumbs.db
 # Editor backup files #
 #######################
 *~
+.DS_Store
+venv

--- a/docs/source/contributing/walkthrough.md
+++ b/docs/source/contributing/walkthrough.md
@@ -172,7 +172,7 @@ Create new SATRE specification issue
 
 3. Fill in the template and select `Submit new issue`.
 
-For more information on how Issues are being governed, see our [Contributing process](https://satre-specification.readthedocs.io/en/latest/contributing.html#contributing-contribution-process)
+For more information on how Issues are being governed, see our [Contributing process](https://satre-specification.readthedocs.io/en/latest/contributing/index.html)
 
 #### Pull requests
 


### PR DESCRIPTION
fix link and add venv to gitignore for docs builders