### PR TITLE
Add summary of contributing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 [![CoC](https://img.shields.io/badge/Code%20of%20Conduct-Contributor%20Covenant-blue?style=flat-square)](https://github.com/sa-tre/satre-specification/blob/main/CODE_OF_CONDUCT.md)
 [![Docs](https://img.shields.io/readthedocs/satre-specification?label=build&style=flat-square)](https://satre-specification.readthedocs.io/en/latest/)
 
-**[The specification is a living document hosted here on our Read the Docs site](https://satre-specification.readthedocs.io/en/latest/)**. The source files can also be viewed here on GitHub at [docs/source/](docs/source/).
+**[The specification is a living document hosted here on our Read the Docs site](https://satre-specification.readthedocs.io/en/latest/)**.
+To contribute to SATRE see https://satre-specification.readthedocs.io/en/latest/contributing/
 
 Welcome to the SATRE Specification Repository!
 This repository stores the technical documents that outlines a reference architecture for Trusted Research Environments.

--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -2,9 +2,19 @@
 
 # ✨ Contributing to the SATRE Specification
 
-🎉 **Welcome to the SATRE specification!** 🎉
-
 _We're excited that you want to contribute_ 🚀
+
+Some ways to immediately get involved are:
+
+- [**Join a Collaboration Cafe**](https://forms.office.com/e/HdaVSj2V0c):
+  These are online events where we discuss the specification and other TRE topics. They are a great way to meet other members of the community, find out more about the project, and are open to everyone.
+- [**Sign-up for email updates**](https://forms.office.com/e/FuFyNGx3hw) from the SATRE project
+- [**Read the current SATRE specification**](https://satre-specification.readthedocs.io/en/stable/)
+- **Provide feedback and suggestions** on the specification:
+  - If you are a GitHub user please [open or comment on an issue](https://github.com/sa-tre/satre-specification/issues)
+  - Alternatively, you can [fill in this form (no login needed)](https://forms.office.com/Pages/ResponsePage.aspx?id=OTEyrjoJKk2Bpl0zS82QGQQh5LWVyKJMjCf72dnH9PNUOUwzMlJWUFExQVBDRVBEOVlWRjY5UjVUSi4u)
+
+---
 
 We want to ensure that every user and contributor feels welcome, included and supported to participate in the SATRE project and community.
 We hope that the information provided in this document will make it as easy as possible for you to get involved.


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [x] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary
Adds some links to the contributing doc so people can immediately get involved without reading a long document

I haven't included the glossary because I don't think the gdoc is in a good state for contributions at the moment

### :closed_umbrella: Related issues

Closes https://github.com/sa-tre/satre-specification/issues/168

### :raising_hand: Acknowledging contributors

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
