### PR TITLE
Change evaluation scoring descriptions

### DIFF
--- a/docs/source/evaluation.md
+++ b/docs/source/evaluation.md
@@ -9,9 +9,9 @@ The scoring system is:
 
 - 0: **Not met** Does not meet requirements
 - 1: **Sufficient** Requirements met but substantial scope for improvement
-- 2: **Satisfied** Requirements met and limited scope for improvement 
+- 2: **Satisfied** Requirements met and limited scope for improvement
 
-0 means you have failed to meet the requirement. 
+0 means you have failed to meet the requirement.
 A score of 1 or above means you have met the requirement.
 Although both 1 and 2 indicate a TRE meets the requirement, the distinction lies in the quality of the components which address the requirement.
 

--- a/docs/source/evaluation.md
+++ b/docs/source/evaluation.md
@@ -7,9 +7,13 @@
 You should score your TRE against each statement in the SATRE specification.
 The scoring system is:
 
-- 0: **Fail** (we do not do this)
-- 1: **Needs improvement** (we do this but want to do better)
-- 2: **Sufficient** (we do this and are currently happy with it)
+- 0: **Not met** Does not meet requirements
+- 1: **Sufficient** Requirements met but substantial scope for improvement
+- 2: **Satisfied** Requirements met and limited scope for improvement 
+
+0 means you have failed to meet the requirement. 
+A score of 1 or above means you have met the requirement.
+Although both 1 and 2 indicate a TRE meets the requirement, the distinction lies in the quality of the components which address the requirement.
 
 ## Examples
 


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [ ] This pull request has had the appropriate labels assigned
- [ ] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
-->

Based on a discussion during a self-evaluation session between @JimMadge, @martintoreilly, @harisood and @craddm, we suggest that the wording for the evaluation scoring system needs to be clarified.

@JimMadge's impressions of the discussion:
- Clarity is needed on which scores *meet* and which scores *do not meet* requirements.
- We are mixing some sort of objective standard against the requirements with a more subjective impression of ‘how good we are at this’ on one scale.
  We may or may not want to do that.
  We _could_ separate those aspects (e.g. a matrix)
- If we want a scale where two organisations rating the same implementation come to the same score, we would need to remove the subjective aspect of scoring.

@craddm:
- suggested wording in the PR is mine, adapted from a suggestion @martintoreilly made.
- **needs improvements** implies that something doesn't meet the standard
- this suggested wording is less (directly) about whether a rater *feels happy* about the current implementation, and more about whether they think they have a jumble of homebrew scripts that do the job or an all-singing, all-dancing fully automated system 

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
