### PR TITLE
Add version at the end of the evaluation XLS

### DIFF
--- a/docs/extensions/satrecsv.py
+++ b/docs/extensions/satrecsv.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import warnings
 from os import path
+from os import getenv
+from subprocess import check_output
 from typing import TYPE_CHECKING, Any, Sequence
 
 from docutils import nodes, writers
@@ -24,12 +26,35 @@ from io import BytesIO
 from openpyxl import Workbook
 from openpyxl.styles import Font
 
+
 if TYPE_CHECKING:
     from sphinx.application import Sphinx
     from docutils.nodes import Element, Text
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_version() -> str:
+    """
+    Obtain a version to use in documentation.
+
+    If this is readthedocs use the RTD environment variables (and the git SHA if this isn't a tag), otherwise attempt to
+    lookup the git version
+    """
+    git_sha = check_output(["git", "rev-parse", "HEAD"]).strip().decode()
+
+    # https://docs.readthedocs.io/en/stable/reference/environment-variables.html
+    rtd_version_slug = getenv("READTHEDOCS_VERSION")
+    rtd_version_type = getenv("READTHEDOCS_VERSION_TYPE")
+
+    if rtd_version_slug and rtd_version_type:
+        if rtd_version_type == "tag":
+            return rtd_version_slug
+        else:
+            return f"{rtd_version_slug}-{git_sha}"
+    else:
+        return check_output(["git", "describe", "--always"]).strip().decode()
 
 
 class SatreXlsxWriter(writers.Writer):
@@ -49,6 +74,8 @@ class SatreXlsxWriter(writers.Writer):
         self.interested = None
 
     def translate(self) -> None:
+        version = get_version()
+
         visitor = self.builder.create_translator(self.document, self.builder)
         self.document.walkabout(visitor)
 
@@ -92,6 +119,9 @@ class SatreXlsxWriter(writers.Writer):
 
         for c, cell in enumerate(ws[1]):
             ws.column_dimensions[cell.column_letter].width = column_widths[c]
+
+        ws.append([])
+        ws.append(["Version", version])
 
         buffer = BytesIO()
         wb.save(buffer)


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

Adds a new row at the end of the evaluation spreadsheet that includes the SATRE version.

For a tag this _should_ just be the tag. For everything else it should be a combination of the [RTD slug](https://docs.readthedocs.io/en/stable/reference/environment-variables.html#envvar-READTHEDOCS_VERSION) and the git SHA.

When built locally the output of `git describe` is used:

![image](https://github.com/sa-tre/satre-specification/assets/1644105/a5db2a56-b367-44d2-a628-3956f14afa3d)


### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
