### PR TITLE
Invalid use of `Required` Importance, should be `Mandatory`

### DIFF
--- a/docs/source/pillars/computing_technology.md
+++ b/docs/source/pillars/computing_technology.md
@@ -41,7 +41,7 @@ This may include desktop, command-line and/or code-submission interfaces.
   - A TRE user must not be able to copy sensitive data out of a workspace using the system clipboard.
     A TRE may allow user to paste text into a workspace.
     This might not be relevant to your TRE, for example if your user interface does not have a clipboard.
-  - Required
+  - Mandatory
 * - 2.1.2.
   - Your TRE workspace should provide an environment familiar to your users.
   - This may take the form of a virtual Windows or Linux desktops, non-desktop interfaces such as JupyterLab and other web applications, or a terminal.


### PR DESCRIPTION
## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

In today's Collaboration Cafe someone spotted an outdated use of the `Required` Importance, we've standardised on`Mandatory`

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
