### PR TITLE
Rewrite front-page to be more relevant to readers, ensure there's an entrypoint to the specification content

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,7 +28,8 @@ extensions = [
     "satrecsv",
 ]
 
-myst_enable_extensions = ["colon_fence", "deflist"]
+# https://myst-parser.readthedocs.io/en/latest/syntax/optional.html
+myst_enable_extensions = ["colon_fence", "deflist", "fieldlist"]
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),

--- a/docs/source/evaluation.md
+++ b/docs/source/evaluation.md
@@ -58,6 +58,8 @@ If all the **Mandatory** statements in a capability are met, either at level **1
 If all capabilities in a pillar are met then the pillar is met.
 If all pillars are met then the SATRE specification is met.
 
+(evaluate_spreadsheet)=
+
 ## Evaluation spreadsheet
 
 You can use this {download}`spreadsheet <../build/satrecsv/satre.xlsx>` as a template for your evaluation.

--- a/docs/source/evaluation.md
+++ b/docs/source/evaluation.md
@@ -28,23 +28,18 @@ By scoring your institutions' TRE against the specification using the method bel
 SATRE is _not_ a technical standard for which formal accreditation can be achived. For more info see: {ref}`is_standard`
 :::
 
+(scoring_method)=
+
 ## Method
 
-You should score your TRE against each statement in the SATRE specification.
-The scoring system is:
+You should score your TRE against each statement in the SATRE specification using this scoring system:
 
-0 (Not met)
-: The TRE does not meet this requirement
+:0 Not met: The TRE does not meet this requirement (the TRE is not SATRE compliant)
+:1 Sufficient: The TRE meets this requirement met but there is substantial scope for improvement
+:2 Satisfied: The TRE meets this requirement met but there may still be scope for improvement
 
-1 (Sufficient)
-: The TRE meets this requirement met but there is substantial scope for improvement
-
-2 (Satisfied)
-: The TRE meets this requirement met but there may still be scope for improvement
-
-**0** means you have failed to meet the requirement.
 A score of **1** or above means you have met the requirement.
-Although both **1** and **2** indicate a TRE meets the requirement, they indicate different levels of possible improvement.
+Optionally you can use **1** and **2** to indicate potential areas of improvement in your TRE.
 
 An evaluation may simply give your TRE scores for each statement.
 We recommend a more detailed evaluation, which includes a score, a justification and, where applicable, suggestions for improvement.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -55,15 +55,10 @@ We encourage all TREs in the UK to {ref}`evaluate <evaluation>` themselves again
 
 If you are familiar with SATRE and want to evaluate your own TRE you can jump straight to the {ref}`evaluation section <evaluation>` which includes an {ref}`Excel spreadsheet <evaluate_spreadsheet>` you can use for your evaluation.
 
-If this is your first time here we recommend reading:
+If this is your first time here we recommend reading the rest of this page to understand the background behind SATRE, followed by:
 
 - {ref}`Frequently asked questions <faqs>`
-- {ref}`Background to the specification <specification>`
-- The specification, which is split into four pillars:
-  - {ref}`pillar_information_governance`
-  - {ref}`pillar_computing_technology`
-  - {ref}`pillar_data_management`
-  - {ref}`pillar_supporting`
+- {ref}`The specification <specification>`
 - {ref}`How to evaluate your TRE <evaluation>`
 
 (what_is_satre)=
@@ -72,16 +67,13 @@ If this is your first time here we recommend reading:
 
 The SATRE project aims to provide a Standard Architecture for {ref}`Trusted Research Environments (TREs) <what_tre>`.
 
-The **project goals** are to:
+The SATRE specification is our attempt to compile and document knowledge, best practices and capabilities around TRE building and operation from different institutions.
+This includes all aspects of TRE provision such as information governance procedures, computing technology, data management and other capabilities.
 
-1. Compile and document knowledge, best practices and capabilities around TRE building and operation from different institutions; this includes all aspects of TRE provision such as information governance procedures, computing technology, data management and other capabilities.
-2. Enable the {ref}`Operators <infrastructure_roles>` of TREs to benefit from this knowledge, and empower them to improve their TREs with the suggested capabilities.
-3. Aid the {ref}`Developers and Builders <infrastructure_roles>` of new TREs in their thinking and decision making.
+SATRE should
 
-To _achieve_ these goals we have:
-
-1. Written a {ref}`comprehensive architecture specification <specification>` which describes the features and capabilities that a TRE should have.
-2. Documented a method for {ref}`evaluating TREs against this specification <evaluation>` and performed example evaluations of existing TREs with this method.
+- Enable the {ref}`Operators <infrastructure_roles>` of TREs to benefit from this knowledge, and empower them to improve their TREs with the suggested capabilities.
+- Aid the {ref}`Developers and Builders <infrastructure_roles>` of new TREs in their thinking and decision making.
 
 (satre_why)=
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -45,11 +45,30 @@ contributing/walkthrough.md
 contributing/contributors.md
 ```
 
+The SATRE project provides a Standard Architecture for {ref}`Trusted Research Environments (TREs) <what_tre>`, incorporating knowledge and best practices from multiple institutions and sectors across the UK.
+
+It aims to standardise the capabilities of TREs, making it easier for users, operators, and developers to work with sensitive data, and making the operation of TREs more transparent to data owners and the general public.
+
+We encourage all TREs in the UK to {ref}`evaluate <evaluation>` themselves against the SATRE specification, and to {ref}`contribute <contributing>` to the project.
+
+## Getting started
+
+If you are familiar with SATRE and want to evaluate your own TRE you can jump straight to the {ref}`evaluation section <evaluation>` which includes an {ref}`Excel spreadsheet <evaluate_spreadsheet>` you can use for your evaluation.
+
+If this is your first time here we recommend reading:
+
+- {ref}`Frequently asked questions <faqs>`
+- {ref}`Background to the specification <specification>`
+- The specification, which is split into four pillars:
+  - {ref}`pillar_information_governance`
+  - {ref}`pillar_computing_technology`
+  - {ref}`pillar_data_management`
+  - {ref}`pillar_supporting`
+- {ref}`How to evaluate your TRE <evaluation>`
+
 (what_is_satre)=
 
 ## 👀 What is SATRE?
-
-<!-- What are TREs, how many exist, the broad categories -->
 
 The SATRE project aims to provide a Standard Architecture for {ref}`Trusted Research Environments (TREs) <what_tre>`.
 

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -65,7 +65,7 @@ There might be good reasons why any particular TRE does not possess one or more 
 
 (satre_pillars)=
 
-### Specification Pillars and Capabilities
+## Specification Pillars and Capabilities
 
 The SATRE specification contains three core pillars for a TRE, plus supporting capabilities:
 

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -1,13 +1,13 @@
 (specification)=
 
-# What is the SATRE specification?
-
-<!-- What this document intends to do (and what it doesn't), the level of detail we aim for contrasted with other technical standards -->
-
-The SATRE specification is our attempt to compile and document knowledge, best practices and capabilities around TRE building and operation from different institutions.
-This includes all aspects of TRE provision such as information governance procedures, computing technology, data management and other capabilities.
+# The SATRE specification
 
 The specification is presented in terms of the capabilities that a team running a TRE should aim for across all aspects of TRE provision.
+
+The specification is split into {ref}`four pillars <satre_pillars>`.
+
+## Structure of the specification
+
 This page explains what the specification is, and how it's structured. Consult the {ref}`FAQs <faqs>` for more on what the specification _is not_.
 
 :::{note}
@@ -16,26 +16,16 @@ Throughout this document, we will use the term "{ref}`TRE operator <infrastructu
 
 The TRE capabilities are broken down into components.
 Each component is a statement of a process, method or practice that the operators should have in place to ensure they fulfil the capability requirements.
-These components are each labelled with an importance.
-The importance is one of **mandatory**, **recommended** or **optional**.
+These components are each labelled with an importance:
 
-:::{note}
-The intended meaning of the capability component importance labels is as follows:
-
-Mandatory
-: This is required. If this component is not supported, then the capability, and the specification, is not met.
-
-Recommended
-: We believe that TREs should have this component. It makes a TRE better.
-
-Optional
-: We believe many TREs would benefit from this component. However, we recognise there are reasons a {ref}`TRE operator <infrastructure_roles>` may actively choose not to support this component.
-:::
+:Mandatory: This is required. If this component is not supported, then the capability, and therefore the specification, is not met.
+:Recommended: Most TREs should have this component, but it is not essential.
+:Optional: Many TREs would benefit from this component. However, we recognise there are reasons a {ref}`TRE operator <infrastructure_roles>` may actively choose not to support this component.
 
 {ref}`TRE operator <infrastructure_roles>`s are able to demonstrate that they meet the specification by showing they can fulfil all **mandatory** components.
 Future versions of the specification may introduce more granular levels of evaluation, for instance tiered level of accreditation based on fulfilment of mandatory, recommended and optional components respectively.
 
-Any particular TRE implementation should be able to score itself against each capability as either **supported**, **partially supported** or **unsupported** (see {ref}`evaluation` for details).
+Any particular TRE implementation should be able to {ref}`score itself against each capability <scoring_method>`.
 
 ## Structure
 
@@ -48,20 +38,14 @@ The SATRE specification contains four key parts:
 SATRE Specification Architecture
 ```
 
-{ref}`Architectural Principles <satre_principles>`
-: The {term}`principles <architectural principle>` that all {ref}`TRE operator <infrastructure_roles>`s looking to use the specification should hold themselves accountable to.
-
-{ref}`Specification Pillars <satre_pillars>`
-: The broad areas of TRE provisioning the specification covers.
-
-Each pillar is broken down into several {term}`TRE Capabilities <capability>`.
-
-Each capability consists of one or more {term}`TRE Capability Components <component>`.
+:{ref}`Architectural Principles <satre_principles>`: The {term}`principles <architectural principle>` that all {ref}`TRE operator <infrastructure_roles>`s looking to use the specification should hold themselves accountable to.
+:{ref}`Specification Pillars <satre_pillars>`: The broad areas of TRE provisioning the specification covers.
+:TRE Capabilities: Pillars are broken down into {term}`capabilities <capability>`
+:TRE Capability Components: Capabilities are broken down into one or more {term}`components <component>`
 
 Together, these provide a framework that {ref}`TRE operator <infrastructure_roles>`s can measure themselves against.
 
-{ref}`Roles <satre_roles>`
-: In addition, we also describe some {term}`roles <role>` that are necessary for the operation and use of a TRE.
+:{ref}`Roles <satre_roles>`: We also describe some {term}`roles <role>` that are necessary for the operation and use of a TRE.
 
 (satre_principles)=
 
@@ -83,7 +67,7 @@ There might be good reasons why any particular TRE does not possess one or more 
 
 ### Specification Pillars and Capabilities
 
-The SATRE specification contains three core pillars for a TRE:
+The SATRE specification contains three core pillars for a TRE, plus supporting capabilities:
 
 ```{figure} ../images/Capability_Map/full.drawio.svg
 :alt: SATRE Pillars Capability Map
@@ -92,14 +76,14 @@ The SATRE specification contains three core pillars for a TRE:
 SATRE Pillars Capability Map
 ```
 
-{ref}`Information governance <pillar_information_governance>`
+{ref}`1. Information governance <pillar_information_governance>`
 : What the {ref}`TRE operator <infrastructure_roles>`s do to ensure information risk is measured and managed to an acceptable level.
 
-{ref}`Computing technology <pillar_computing_technology>`
+{ref}`2. Computing technology <pillar_computing_technology>`
 : What the {ref}`TRE operator <infrastructure_roles>`s do to manage systems for storing, retrieving, and sending information.
 
-{ref}`Data management <pillar_data_management>`
+{ref}`3. Data management <pillar_data_management>`
 : What the {ref}`TRE operator <infrastructure_roles>`s do to manage data assets and ensure information remains secure.
 
-In addition to these capabilities, any {ref}`TRE operator <infrastructure_roles>` will need to possess various {ref}`supporting capabilities <pillar_supporting>`.
-Examples of supporting capabilities include complying with legal requirements and managing relationships with stakeholders.
+{ref}`4. Supporting capabilities <pillar_supporting>`
+: A {ref}`TRE operator <infrastructure_roles>` will need to possess various supporting capabilities, such as complying with legal requirements and managing relationships with stakeholders.


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

The front-page focusses on the background to SATRE. We should make the front-page more attractive to people, and get straight to the point.

This includes making the evaluation spreadsheet more obvious (feedback from a Collaboration Cafe)

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
