### PR TITLE
Add external security standards back

### DIFF
--- a/docs/source/evaluations/alan_turing_institute.md
+++ b/docs/source/evaluations/alan_turing_institute.md
@@ -28,6 +28,9 @@
     ##### Potential Improvements
     - Improve our document handling workflow by developing an Information Governance App through which all projects can be managed directly by approved users.
 * - 1.1.3.
+  -
+  -
+* - 1.1.4.
   - 1
   - - The Institute has Legal and Data Protection Teams who ensure that projects meet our institutional requirements.
     - Our sysadmin team is currently appropriately sized for the number of projects we are handling.

--- a/docs/source/pillars/information_governance.md
+++ b/docs/source/pillars/information_governance.md
@@ -52,6 +52,10 @@ This {term}`business process <business process>` involves measures, safeguards, 
   - You must ensure controls are implemented to ensure the requirements are met.
   - Control implementation should be systematic and directly aligned to the internal and stakeholder requirements.
   - Mandatory
+* - 1.1.3.
+  - Your TRE should adhere to one or more external security standards.
+  - These should be stated to all stakeholders.
+  - Recommended
 ```
 
 ### Resource Allocation Process
@@ -66,7 +70,7 @@ This {term}`business process <business process>` involves assigning, distributin
   - Statement
   - Guidance
   - Importance
-* - 1.1.3.
+* - 1.1.4.
   - You must ensure there are adequate resources to meet information governance requirements.
   - Ensuring information governance controls are suitable and enforced requires an investment of funding and people appropriate to the size of the TRE.
   - Mandatory


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

I removed `Your TRE should adhere to one or more external security standards.` in https://github.com/sa-tre/satre-specification/pull/269/files#r1345595654 as it doesn't fit in, and is arguably covered by
[Internal Audit Process](https://satre-specification.readthedocs.io/en/latest/pillars/information_governance.html#internal-audit-process)

However if we did want to explicity say something about adhering to external security standards (I'm undecided) then this is one suggestion for adding it to the IG pillar.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
