### PR TITLE
3.3.8: output checks can't control what's submitted to them

### DIFF
--- a/docs/source/pillars/data_management.md
+++ b/docs/source/pillars/data_management.md
@@ -198,7 +198,7 @@ The ability of the {ref}`TRE operator <infrastructure_roles>` to ensure outputs 
   - Optional
 * - 3.3.8.
   - TRE outputs should be limited to the minimum required for sharing results of any analyses.
-  - This reduces the burden on {ref}`output checkers <data_roles>`, decreases the risk of inadvertent disclosure, and makes it easier to comply with data protection legislation (e.g. GDPR).
+  - This decreases the risk of inadvertent disclosure, and makes it easier to comply with data protection legislation (e.g. GDPR).
   - Recommended
 ```
 


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

TRE output checkers can't control what researchers to submit to them so this statement doesn't reduce the burden on them.

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [x] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
