### PR TITLE
Scoring: Use N/A for recommended/optional, 0 is only a failure for Mandatory

### DIFF
--- a/docs/source/evaluation.md
+++ b/docs/source/evaluation.md
@@ -37,9 +37,10 @@ For more info see: {ref}`is_standard`
 
 You should score your TRE against each statement in the SATRE specification using this scoring system:
 
-:0 Not met: The TRE does not meet this requirement (the TRE is not SATRE compliant)
+:0 Not met: The TRE does not meet this requirement (if this is **Mandatory** this means the TRE is not SATRE compliant)
 :1 Sufficient: The TRE meets this requirement met but there is substantial scope for improvement
 :2 Satisfied: The TRE meets this requirement met but there may still be scope for improvement
+:N/A: Not applicable: The statement is not relevant to a TRE, may apply to **Recommended** or **Optional** statements
 
 A score of **1** or above means you have met the requirement.
 Optionally you can use **1** and **2** to indicate potential areas of improvement in your TRE.


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

Clarifies the scoring system:
- `0` is only a SATRE failure for Mandatory
- `N/A` should be used if a statement is not relevant

### :closed_umbrella: Related issues

Closes https://github.com/sa-tre/satre-specification/issues/290

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
