### PR TITLE
Hide all-contributors doc links

### DIFF
--- a/docs/source/contributing/index.md
+++ b/docs/source/contributing/index.md
@@ -179,6 +179,9 @@ To report Code-of-Conduct violations, please use the contact [specified in the C
 
 We welcome and recognise all kinds of contributions, from discussing ideas, suggesting features, improving governance, maintaining the project, and more.
 
+<!-- Uncomment when https://github.com/orgs/the-turing-way/discussions/4245 is resolved -->
+
+<!--
 This project follows the [All Contributors specification](https://allcontributors.org/docs/en/overview).
 The All Contributors bot usage is described [here](https://allcontributors.org/docs/en/bot/usage).
 
@@ -203,3 +206,4 @@ What happens if you accidentally run the bot before the previous run was merged 
 Simply close the pull request and delete the branch (`all-contributors/add-<username>`).
 If you are unable to do this for any reason, please let us know by opening an issue, and SATRE team members will be very happy to help!
 :::
+-->


### PR DESCRIPTION
https://allcontributors.org is down, it's not clear when it will return. See https://github.com/orgs/the-turing-way/discussions/4245

This comments out the all-contributors documentation as a quick fix for the broken links.

## :white_check_mark: Checklist

<!--
Replace the empty checkboxes [ ] below with checked ones [x] accordingly.
-->

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
