### PR TITLE
Version 2.0 draft - with federation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ __pycache__
 # Kiro AI assistant files
 .kiro/
 
+# Local source files directory
+sourcefiles/
+

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: 1200px;
+}

--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,3 +1,3 @@
 .wy-nav-content {
-    max-width: 1200px;
+  max-width: 1200px;
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -76,8 +76,8 @@ html_theme_options = {
 html_logo = "../images/SATRE_Stacked_Dark.png"
 
 # Add custom CSS and JavaScript
-# html_static_path = ["_static"]
-# html_css_files = ["custom.css"]
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 # html_js_files = ["custom.js"]
 
 # -- Options for EPUB output

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -71,11 +71,11 @@ Personal and sensitive data collected for operational, commercial, or government
 
 ## The SATRE Specification
 
-The [SATRE specification](specification.md) defines 160 requirements organized into capabilities that TREs should implement to ensure safe, secure, and effective research with sensitive data. Each requirement is classified as either Mandatory or Optional, providing flexibility while maintaining essential standards.
+The [SATRE specification](specification.md) defines requirements organized into capabilities that TREs should implement to ensure safe, secure, and effective research with sensitive data. Each requirement is classified as either Mandatory, Recommended, or Optional, providing flexibility while maintaining essential standards.
 
-The requirements are structured across four interconnected pillars.
+The core specification is structured across four interconnected pillars, with an additional fifth pillar for TREs wishing to federate.
 
-### Four Pillars of SATRE
+### Four Core Pillars of SATRE
 
 **1. [Information Governance](specification.md#information-governance)**
 Quality management, risk management, training delivery, member accreditation, and governance procedures that ensure TREs operate safely and ethically.<br>
@@ -85,6 +85,11 @@ End-user computing experience, infrastructure management, information security, 
 Data lifecycle management, identity and access management, output management, information discovery, and research metadata capabilities.<br>
 **4. [Supporting Capabilities](specification.md#supporting-capabilities)**
 Financial management, public engagement and involvement, project management, procurement, and other essential operational functions.
+
+### Federation Extension
+
+**5. [Federation](specification.md#federation)**
+An extension to the core SATRE specification for TREs wishing to operate as part of a federation. This pillar covers federation governance, member accreditation, study management, information security, infrastructure management, data management, and financial management across multiple federated TRE partners.
 
 ## The SATRE Architecture
 

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -46,7 +46,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.1.02
+    requirement_index: 1.2.02
     statement: You must use versioning and a codified change procedure for all
       policies and standard operating procedures.
     guidance: This includes recording dates of changes, person responsible for
@@ -1348,6 +1348,17 @@ specification:
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-b039ff3b59d047f0b6e9bd95ec5f7c6f
   - pillar: Data management
+    capability: Data Lifecycle Management
+    capability_index: "3.1"
+    requirement_index: 3.1.14
+    statement: Archived data within the TRE should be read only.
+    guidance:
+      "Archived data by its very nature should not change and therefore be
+      maintained as a read only store.\nIf an update is required, it may be pulled
+      from archive into a separate operational store."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-3fe25645d78645b7a5edef1e8234b769
+  - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
     requirement_index: 3.2.01
@@ -1610,17 +1621,6 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.8"
-    requirement_index: 3.8.01
-    statement: Archived data within the TRE should be read only.
-    guidance:
-      "Archived data by its very nature should not change and therefore be
-      maintained as a read only store.\nIf an update is required, it may be pulled
-      from archive into a separate operational store."
-    importance: Recommended
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-3fe25645d78645b7a5edef1e8234b769
-  - pillar: Data management
-    capability: Data Lifecycle Management
-    capability_index: "3.8"
     requirement_index: 3.8.02
     statement: Long-term archives must be held in simple, standard formats to
       ensure accessibility.
@@ -1667,7 +1667,7 @@ specification:
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6938
   - pillar: Supporting Capabilities
-    capability: Projectect and Programme Management
+    capability: Project and Programme Management
     capability_index: "4.2"
     requirement_index: 4.2.02
     statement: You should not give project managers direct access to the TRE.
@@ -2046,7 +2046,7 @@ specification:
     capability: Federation Information Security
     capability_index: "5.4"
     requirement_index: 5.4.01
-    statement: The federation must implement network-level standards for
+    statement: The federation should implement network-level standards for
       cryptographic key and secrets management.
     guidance: Automated secrets management
     importance: Recommended
@@ -2089,7 +2089,7 @@ specification:
   - pillar: Federation
     capability: Federation Information Security
     capability_index: "5.4"
-    requirement_index: 5.4.06
+    requirement_index: 5.4.05
     statement: Shared federation services must maintain security logs of events
       including authentication and data transfer.
     guidance: The federation should implement shared visibility of security logs
@@ -2097,7 +2097,7 @@ specification:
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
-    capability: Federation Infrastructure management
+    capability: Federation Infrastructure Management
     capability_index: "5.5"
     requirement_index: 5.5.01
     statement: Federation members must maintain accurate configuration

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -2000,7 +2000,7 @@ specification:
     capability_index: "5.1"
     requirement_index: 5.1.10
     statement: Where federation involves members of the public there should be
-      representation from across all member TREs areas
+      representation from across all member TRE population areas
     guidance: "When moving from a single TRE to a federation it is important to
       consider public representation coving data across the entire federation. This
       is especially relevant for where member TREs cover different populations (e.g.

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1880,8 +1880,7 @@ specification:
     requirement_index: 5.1.01
     statement: The federation must define a scope and governance structure for
       the federation made up of member TREs and interested parties.
-    guidance:
-      "A federation may have 2 levels of management with top management
+    guidance: "A federation may have 2 levels of management with top management
       making decisions around risk, and resources with an operation group making
       day-to-day decisions related to the running of the federation.\n\nInterested
       parties might include PPIE, Data Providers, member TRE operators etc.\n\nEstablish
@@ -1915,8 +1914,7 @@ specification:
       each member TRE. Member TREs must make their compliance status with these
       rules available for audit by the federation, other members and external
       parties as appropriate.
-    guidance:
-      "Standards and rules expected or required by the federation may be
+    guidance: "Standards and rules expected or required by the federation may be
       specific to the federation or require meeting external standards (EG. SATRE,
       DSPT, ISO 27001,CAF)  these should be tracked and be accessible by the federation
       and it's members.\n\nThese rules are likely to be a mix of high-level organisational
@@ -1939,7 +1937,7 @@ specification:
     capability_index: "5.1"
     requirement_index: 5.1.05
     statement: The federation must agree a process to create, update and retire
-      rules formal rules and standard operating procedures and make them
+      rules formal and standard operating procedures and make them
       available to TRE members.
     guidance:
       "Some shared processes will be critical to the operation of the federation
@@ -1968,7 +1966,7 @@ specification:
     capability_index: "5.1"
     requirement_index: 5.1.07
     statement: The federation should agree a consistent approach to risk
-      assessment and treatment. Where multiple approaches are used equivalence
+      assessment and treatment. Where multiple approaches are used, equivalence
       must be established.
     guidance: It is likely that different organisations will have different risk
       matrices and risk tolerance. The federation should assess combined risk,
@@ -2003,8 +2001,7 @@ specification:
     requirement_index: 5.1.10
     statement: Where federation involves members of the public there should be
       representation from across all member TREs areas
-    guidance:
-      "When moving from a single TRE to a federation it is important to
+    guidance: "When moving from a single TRE to a federation it is important to
       consider public representation coving data across the entire federation. This
       is especially relevant for where member TREs cover different populations (e.g.
       regions, counties) or data domains (e.g. Health, financial data)."
@@ -2017,11 +2014,11 @@ specification:
     statement: The federation must agree baseline competency requirements for
       all users.
     guidance:
-      "Competency ensures a consistent definition of a \"Safe Researcher\".
+      'Competency ensures a consistent definition of a "Safe Researcher".
       Ideally all federations use an existing registry such as https://safepeopleregistry.org/en.
       Alternatively, standardised training could be provided by the federation or
       multiple trainings could be acceptable. Training status of users should be accessible
-      programmatically by all member TREs."
+      programmatically by all member TREs.'
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-member-accreditation
   - pillar: Federation
@@ -2029,8 +2026,7 @@ specification:
     capability_index: "5.4"
     requirement_index: 5.3.01
     statement: The federation must maintain a register of "Safe Projects"
-    guidance:
-      "The project register should be accessible programmatically by all
+    guidance: "The project register should be accessible programmatically by all
       member TREs, good practice to make it available to public."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
@@ -2072,7 +2068,7 @@ specification:
     capability: Federation Information Security
     capability_index: "5.5"
     requirement_index: 5.5.03
-    statement: The federation should support a common user and machine
+    statement: The federation should support common user and machine
       identities with a defined set of attributes for use across the federation.
     guidance: Identity provider federation with agreed, shared attributes for
       each user or machine identities.

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -2061,7 +2061,7 @@ specification:
       "a federation wide incident response process should cover incidents
       affecting member TREs, the federation and federation projects and include confidentiality,
       integrity and availability.\n\nExamples of such incidents are data quality
-      issues or availability or data at  a member TRE."
+      issues or availability of data at  a member TRE."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1184,6 +1184,17 @@ specification:
       from unauthorised access."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-99ff165db6264d4ba94b36d9d014f9f4
+  - pillar: Computing technology and Information Security
+    capability: Information Security
+    capability_index: "2.5"
+    requirement_index: 2.5.19
+    statement: Your TRE could use threat modelling definition to identify
+      areas of risk to infrastructure.
+    guidance: "Understanding threats to the TRE may be challenging.
+      Threat modelling provides a structured process for TREs to understand and
+      assess threats.\n\nInformation on threat models here:\nhttps://owasp.org/www-community/Threat_Modeling"
+    importance: Optional
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-99ff165db6264d4ba94b36d9d014f9f4
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
@@ -1356,6 +1367,19 @@ specification:
       "Archived data by its very nature should not change and therefore be
       maintained as a read only store.\nIf an update is required, it may be pulled
       from archive into a separate operational store."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-3fe25645d78645b7a5edef1e8234b769
+  - pillar: Data management
+    capability: Data Lifecycle Management
+    capability_index: "3.1"
+    requirement_index: 3.1.15
+    statement: Long-term archives must be held in simple, standard formats to
+      ensure accessibility.
+    guidance:
+      "Some data archives may be required by policy or legislation to be kept
+      for very long periods within the scope of the TRE.\nSuch data should be held
+      in the simplest possible file format, conforming to international standards
+      if available, to ensure they are platform and application agnostic."
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-3fe25645d78645b7a5edef1e8234b769
   - pillar: Data management
@@ -1618,19 +1642,6 @@ specification:
       accessible than the data itself.
     importance: Optional
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-e02301f9b1314503934a377bf5642b15
-  - pillar: Data management
-    capability: Data Lifecycle Management
-    capability_index: "3.8"
-    requirement_index: 3.8.02
-    statement: Long-term archives must be held in simple, standard formats to
-      ensure accessibility.
-    guidance:
-      "Some data archives may be required by policy or legislation to be kept
-      for very long periods within the scope of the TRE.\nSuch data should be held
-      in the simplest possible file format, conforming to international standards
-      if available, to ensure they are platform and application agnostic."
-    importance: Recommended
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-3fe25645d78645b7a5edef1e8234b769
   - pillar: Supporting Capabilities
     capability: Business Continuity
     capability_index: "4.1"
@@ -1654,7 +1665,7 @@ specification:
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6936
   - pillar: Supporting Capabilities
-    capability: Projectect and Programme Management
+    capability: Project and Programme Management
     capability_index: "4.2"
     requirement_index: 4.2.01
     statement: You should ensure that all projects using your TRE have a named
@@ -1901,8 +1912,7 @@ specification:
       versus with individual members. Key roles might include TRE provider organisation,
       infrastructure provider, researcher, top management etc.\n\nA document covering
       responsibilities assigned to these roles could include RACI or be based on established
-      model such as those used by public cloud providers.\n\nExample of key roles
-      can be found here: https://satre-specification.readthedocs.io/en/latest/roles.html\n\
+      model such as those used by public cloud providers.\n\nWhere a role name matches one of the [SATRE defined roles](https://satre-specification.readthedocs.io/en/latest/roles.html)\n\ it must follow the definition.
       \nRelated 1.3.4"
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
@@ -1915,15 +1925,13 @@ specification:
       rules available for audit by the federation, other members and external
       parties as appropriate.
     guidance: "Standards and rules expected or required by the federation may be
-      specific to the federation or require meeting external standards (EG. SATRE,
-      DSPT, ISO 27001,CAF)  these should be tracked and be accessible by the federation
-      and it's members.\n\nThese rules are likely to be a mix of high-level organisational
-      requirements and specific controls."
+      specific to the federation or require meeting external standards (e.g ISO 27001). These should be tracked and be accessible by the federation
+      and it's members.\n\nThese rules are likely to be a mix of high-level principles and specific controls."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
   - pillar: Federation
     capability: Federation Governance
-    capability_index: "5.2"
+    capability_index: "5.1"
     requirement_index: 5.1.04
     statement: Federation members must share any relevant incident, audit and
       other quality management data with members.
@@ -2000,39 +2008,38 @@ specification:
     capability_index: "5.1"
     requirement_index: 5.1.10
     statement: Where federation involves members of the public there should be
-      representation from across all member TRE population areas
+      representation from across all member TRE population areas (*optional for TREs without personal data).
     guidance: "When moving from a single TRE to a federation it is important to
       consider public representation coving data across the entire federation. This
       is especially relevant for where member TREs cover different populations (e.g.
       regions, counties) or data domains (e.g. Health, financial data)."
-    importance: Recommended
+    importance: Mandatory*
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
   - pillar: Federation
     capability: Member Accreditation
-    capability_index: "5.3"
+    capability_index: "5.2"
     requirement_index: 5.2.01
     statement: The federation must agree baseline competency requirements for
       all users.
     guidance:
-      'Competency ensures a consistent definition of a "Safe Researcher".
-      Ideally all federations use an existing registry such as https://safepeopleregistry.org/en.
-      Alternatively, standardised training could be provided by the federation or
-      multiple trainings could be acceptable. Training status of users should be accessible
-      programmatically by all member TREs.'
+      'Competency usually includes training and attestation confirming a user understands their
+      responsibilities (i.e. being a "safe researcher"). Federations should use an existing registry such as the [safe people regsiry](https://safepeopleregistry.org) where possible.
+      Alternatively, standardised training could be provided by the federation or multiple trainings could be considered equivalent. Training status of users should be accessible programmatically (E.g. via API) by all member TREs. '
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-member-accreditation
   - pillar: Federation
     capability: Federation Study Management
-    capability_index: "5.4"
+    capability_index: "5.3"
     requirement_index: 5.3.01
     statement: The federation must maintain a register of "Safe Projects"
-    guidance: "The project register should be accessible programmatically by all
-      member TREs, good practice to make it available to public."
+    guidance:
+      "The project register should be accessible programmatically (E.g. via API) by all member TREs, good practice to make it available to public.
+      See HDRUK for recommendations for a data use registry standard"
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
   - pillar: Federation
     capability: Federation Study Management
-    capability_index: "5.4"
+    capability_index: "5.3"
     requirement_index: 5.3.02
     statement: The federation must agree the legal, ethical and compliance
       standards required for a safe federated project.
@@ -2046,10 +2053,11 @@ specification:
     capability: Federation Information Security
     capability_index: "5.4"
     requirement_index: 5.4.01
-    statement: The federation should implement network-level standards for
-      cryptographic key and secrets management.
-    guidance: Automated secrets management
-    importance: Recommended
+    statement: The federation must agree and implement network-level standards for cryptographic key and secrets management.
+    guidance:
+      Automated secrets management and consistent cryptographic standards must be adopted across the federation to ensure credentials,
+      keys, and tokens are systematically rotated, audited, and revoked, and that encryption algorithms and protocols meet a defined minimum baseline that cannot be undermined by the weakest member of the federation.
+    importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Information Security
@@ -2078,23 +2086,10 @@ specification:
     capability: Federation Information Security
     capability_index: "5.4"
     requirement_index: 5.4.04
-    statement: The federation could use threat modelling definition to identify
-      areas of risk to infrastructure.
-    guidance:
-      "Understanding cross threat across multiple organisations may be challenging.
-      Threat modelling provides a structured process for members TREs to discuss and
-      assess threats across a federation.\n\nInformation on threat models here:\nhttps://owasp.org/www-community/Threat_Modeling"
-    importance: Optional
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
-  - pillar: Federation
-    capability: Federation Information Security
-    capability_index: "5.4"
-    requirement_index: 5.4.05
-    statement: Shared federation services must maintain security logs of events
-      including authentication and data transfer.
+    statement: Security logs including authentication and data transfer should be made available to the federation where appropriate.
     guidance: The federation should implement shared visibility of security logs
       where appropriate for federation-wide threat detection.
-    importance: Mandatory
+    importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Infrastructure Management
@@ -2112,12 +2107,10 @@ specification:
     capability: Federation Data Management
     capability_index: "5.6"
     requirement_index: 5.6.01
-    statement: The federation must implement a single, consistent output
-      classification (definition of a safe output)
+    statement: The federation MUST agree an approach to the management of outputs which is implemented by all federation members (definition of a safe output).
     guidance:
-      "Output rule must cover data moving between federation members (outputs
-      from a TRE to the next environment) and research outputs suitable for transfer
-      out of a member TRE.\n\nCheck PIE statement to the right"
+      "Output agreements and rules must cover data moving between federation members (e.g. TRE-to-TRE exchanges) and research outputs
+      leaving the federation (i.e. outputs suitable for release from a TRE to the outside world)."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-data-management
   - pillar: Federation

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -475,6 +475,60 @@ specification:
       record."
     importance: Optional
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-ba6c25da48e94d37abe02e4dca7b55b7
+  - pillar: Information governance
+    capability: Public Involvement and Engagement
+    capability_index: "1.7"
+    requirement_index: 1.7.01
+    statement: All public engagement activities must include a range of
+      perspectives and be inclusive (*optional for TREs without personal data).
+    guidance:
+      "Any public engagement activity carried out by TREs should involve diverse
+      participants and that activities are accessible.\nRecruitment plans should consider
+      how to proactively reach a representative sample of people or target particular
+      groups of people where relevant\nThis could include following guidelines such
+      as PEDRI."
+    importance: Mandatory*
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
+  - pillar: Information governance
+    capability: Public Involvement and Engagement
+    capability_index: "1.7"
+    requirement_index: 1.7.02
+    statement: Details of TRE operations, data available and projects which have
+      accessed the data should be publicly available (*optional for TREs without
+      personal data).
+    guidance:
+      "TREs should be as transparent as possible by providing information
+      online.\nWhere information is made available online this should be written in
+      clear language understandable to general public.\nA record of projects which
+      have accessed data via the TRE should be kept and made available.\nWhere possible
+      it should include name, summaries, public benefit (if relevant) and organisations
+      involved"
+    importance: Mandatory*
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
+  - pillar: Information governance
+    capability: Public Involvement and Engagement
+    capability_index: "1.7"
+    requirement_index: 1.7.03
+    statement: Members of the public should be included in TRE operations and/or
+      oversight (*optional for TREs without personal data).
+    guidance:
+      "Members of the public can be involved via presence on steering groups
+      or project approvals panels.\nAlternatively TRE's can establish separate public
+      panels available for both researchers and TRE staff to consult."
+    importance: Mandatory*
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
+  - pillar: Information governance
+    capability: Public Involvement and Engagement
+    capability_index: "1.7"
+    requirement_index: 1.7.04
+    statement: You should publicly share details of incidents, near misses, and
+      mitigations in a timely fashion, in line with good practices for
+      responsible disclosure.
+    guidance:
+      "This may be via the TRE website or annual reports.\nSharing this information
+      is particularly important when a TRE holds public sector data."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
@@ -1798,63 +1852,9 @@ specification:
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6949
   - pillar: Supporting Capabilities
-    capability: Public Involvement and Engagement
+    capability: Legal Services
     capability_index: "4.8"
     requirement_index: 4.8.01
-    statement: All public engagement activities must include a range of
-      perspectives and be inclusive (*optional for TREs without personal data).
-    guidance:
-      "Any public engagement activity carried out by TREs should involve diverse
-      participants and that activities are accessible.\nRecruitment plans should consider
-      how to proactively reach a representative sample of people or target particular
-      groups of people where relevant\nThis could include following guidelines such
-      as PEDRI."
-    importance: Mandatory*
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
-  - pillar: Supporting Capabilities
-    capability: Public Involvement and Engagement
-    capability_index: "4.8"
-    requirement_index: 4.8.02
-    statement: Details of TRE operations, data available and projects which have
-      accessed the data should be publicly available (*optional for TREs without
-      personal data).
-    guidance:
-      "TREs should be as transparent as possible by providing information
-      online.\nWhere information is made available online this should be written in
-      clear language understandable to general public.\nA record of projects which
-      have accessed data via the TRE should be kept and made available.\nWhere possible
-      it should include name, summaries, public benefit (if relevant) and organisations
-      involved"
-    importance: Mandatory*
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
-  - pillar: Supporting Capabilities
-    capability: Public Involvement and Engagement
-    capability_index: "4.8"
-    requirement_index: 4.8.03
-    statement: Members of the public should be included in TRE operations and/or
-      oversight (*optional for TREs without personal data).
-    guidance:
-      "Members of the public can be involved via presence on steering groups
-      or project approvals panels.\nAlternatively TRE’s can establish separate public
-      panels available for both researchers and TRE staff to consult."
-    importance: Mandatory*
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
-  - pillar: Supporting Capabilities
-    capability: Public Involvement and Engagement
-    capability_index: "4.8"
-    requirement_index: 4.8.04
-    statement: You should publicly share details of incidents, near misses, and
-      mitigations in a timely fashion, in line with good practices for
-      responsible disclosure.
-    guidance:
-      "This may be via the TRE website or annual reports.\nSharing this information
-      is particularly important when a TRE holds public sector data."
-    importance: Recommended
-    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6950
-  - pillar: Supporting Capabilities
-    capability: Legal Services
-    capability_index: "4.9"
-    requirement_index: 4.9.01
     statement: You should identify areas where legal advice may be required and
       ensure that you have ready access to it.
     guidance:
@@ -1866,8 +1866,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6954
   - pillar: Supporting Capabilities
     capability: Legal Services
-    capability_index: "4.9"
-    requirement_index: 4.9.02
+    capability_index: "4.8"
+    requirement_index: 4.8.02
     statement: You should identify areas where advice on data protection issues
       may be required and ensure that you have ready access to it.
     guidance: It is likely that data protection advice will be necessary for
@@ -1876,8 +1876,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6954
   - pillar: Supporting Capabilities
     capability: Legal Services
-    capability_index: "4.9"
-    requirement_index: 4.9.03
+    capability_index: "4.8"
+    requirement_index: 4.8.03
     statement: You should identify who will be responsible for managing
       contracts related to the TRE.
     guidance: These contracts may include data sharing agreements, secondments

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -2,7 +2,7 @@ specification:
   - pillar: Information governance
     capability: Information Governance
     capability_index: "1.1"
-    requirement_index: 1.1.1
+    requirement_index: 1.1.01
     statement: You must gather and monitor the information governance
       requirements needed to fulfil any legal, regulatory and ethical standards.
     guidance:
@@ -14,7 +14,7 @@ specification:
   - pillar: Information governance
     capability: Information Governance
     capability_index: "1.1"
-    requirement_index: 1.1.2
+    requirement_index: 1.1.02
     statement: You must ensure controls are implemented to ensure the
       requirements are met.
     guidance: Control implementation should be systematic and directly aligned
@@ -24,7 +24,7 @@ specification:
   - pillar: Information governance
     capability: Information Governance
     capability_index: "1.1"
-    requirement_index: 1.1.3
+    requirement_index: 1.1.03
     statement: You must ensure there are adequate resources to meet information
       governance requirements.
     guidance: Ensuring information governance controls are suitable and enforced
@@ -35,7 +35,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.1
+    requirement_index: 1.2.01
     statement: You must ensure that changes to policies and standard operating
       procedures can only be made by trusted individuals.
     guidance: It is important to ensure that policies and SOPs are relevant,
@@ -46,7 +46,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.1.2
+    requirement_index: 1.1.02
     statement: You must use versioning and a codified change procedure for all
       policies and standard operating procedures.
     guidance: This includes recording dates of changes, person responsible for
@@ -56,7 +56,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.3
+    requirement_index: 1.2.03
     statement: You should measure the performance of information governance
       within the TRE with regular reporting available to your TRE organisation’s
       management team.
@@ -67,7 +67,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.4
+    requirement_index: 1.2.04
     statement: You must audit your TRE organisation against relevant
       requirements and standards.
     guidance: If you are publicly accredited against a standard, for instance
@@ -78,7 +78,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.5
+    requirement_index: 1.2.05
     statement: You must report on and share outcomes of each audit of your TRE
       organisation with the required bodies.
     guidance: This may include regulatory bodies or the organisations that
@@ -88,7 +88,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.6
+    requirement_index: 1.2.06
     statement: You must ensure that suppliers, contractors and sub-contractors
       with access to your TRE align with your security requirements.
     guidance:
@@ -100,7 +100,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.7
+    requirement_index: 1.2.07
     statement: You must monitor compliance of your suppliers with the terms of
       the contracts.
     guidance:
@@ -113,7 +113,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.8
+    requirement_index: 1.2.08
     statement: You must track and maintain any physical assets used by your TRE.
     guidance:
       "All physical assets should be maintained and covered by warranty if
@@ -124,7 +124,7 @@ specification:
   - pillar: Information governance
     capability: Quality Management
     capability_index: "1.2"
-    requirement_index: 1.2.9
+    requirement_index: 1.2.09
     statement: You must log, track and resolve any issues resulting from
       deviations from processes, incidents and audit findings.
     guidance: This process could, for example, be tracked through an electronic
@@ -170,7 +170,7 @@ specification:
   - pillar: Information governance
     capability: Risk Management
     capability_index: "1.3"
-    requirement_index: 1.3.1
+    requirement_index: 1.3.01
     statement: You must have a way to score risk to understand the underlying
       severity.
     guidance: You have a risk assessment methodology for scoring risks on
@@ -180,7 +180,7 @@ specification:
   - pillar: Information governance
     capability: Risk Management
     capability_index: "1.3"
-    requirement_index: 1.3.2
+    requirement_index: 1.3.02
     statement: You must carry out a data processing assessment for all projects
       requiring a TRE.
     guidance:
@@ -193,7 +193,7 @@ specification:
   - pillar: Information governance
     capability: Risk Management
     capability_index: "1.3"
-    requirement_index: 1.3.3
+    requirement_index: 1.3.03
     statement: You must have a process for designing, implementing and recording
       risk mitigations where indicated by a risk assessment.
     guidance: Actions that are taken or not taken following a risk assessment
@@ -203,7 +203,7 @@ specification:
   - pillar: Information governance
     capability: Risk Management
     capability_index: "1.3"
-    requirement_index: 1.3.4
+    requirement_index: 1.3.04
     statement: You must have a clear set of roles and responsibilities relating
       to risk including who owns risks and how they are escalated and delegated.
     guidance:
@@ -216,7 +216,7 @@ specification:
   - pillar: Information governance
     capability: Risk Management
     capability_index: "1.3"
-    requirement_index: 1.3.5
+    requirement_index: 1.3.05
     statement: You must understand the risk appetite of your TRE organisation.
     guidance: This includes understanding ownership of risk, and ability to
       accept risk which falls outside of the appetite should that become
@@ -226,7 +226,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.1
+    requirement_index: 1.4.01
     statement: You must have checks in place to ensure a project has the legal,
       financial and ethical requirements in place for the duration of the
       project.
@@ -238,7 +238,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.2
+    requirement_index: 1.4.02
     statement: You must have checks in place to ensure that any time limited
       compliance requirements are maintained.
     guidance:
@@ -250,7 +250,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.3
+    requirement_index: 1.4.03
     statement: You must have checks in place to ensure that changes in
       regulations are met for a project.
     guidance:
@@ -259,7 +259,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.4
+    requirement_index: 1.4.04
     statement: You must have standard processes in place for the end of a
       project, that follow all legal requirements and data security best
       practice.
@@ -270,7 +270,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.5
+    requirement_index: 1.4.05
     statement: You could implement a portal that can provide a workflow engine
       and database which automates the processes within this capability.
     guidance:
@@ -283,7 +283,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.6
+    requirement_index: 1.4.06
     statement: You must keep a complete record of all the data assets held
       within the system.
     guidance:
@@ -297,7 +297,7 @@ specification:
   - pillar: Information governance
     capability: Study Management
     capability_index: "1.4"
-    requirement_index: 1.4.7
+    requirement_index: 1.4.07
     statement: You should keep a complete record of all the research studies and
       projects within the TRE current and past.
     guidance: The study register should contain all data related to a study
@@ -308,7 +308,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.1
+    requirement_index: 1.5.01
     statement: You must have a robust method for identifying accredited members
       of your TRE organisation, prior to their accessing of sensitive data.
     guidance: This may include ID checks or email/phone verification.
@@ -317,7 +317,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.2
+    requirement_index: 1.5.02
     statement: You must have clear onboarding processes in place for all roles
       within your TRE organisation.
     guidance: This may include all members signing role-specific terms of use or
@@ -327,7 +327,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.3
+    requirement_index: 1.5.03
     statement: You must have a set of services to manage access to resources
       based on identity.
     guidance: This will include a security model for role based access with
@@ -337,7 +337,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.4
+    requirement_index: 1.5.04
     statement: You must not give anyone access to datasets without agreement
       from the Data Controller.
     guidance: The Data Controller may choose to delegate this authority.
@@ -346,7 +346,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.5
+    requirement_index: 1.5.05
     statement: You must have robust and secure applications in place to
       authenticate users (and services) within the TRE.
     guidance: The number of authentication applications should be kept to a
@@ -357,7 +357,7 @@ specification:
   - pillar: Information governance
     capability: Member Accreditation
     capability_index: "1.5"
-    requirement_index: 1.5.6
+    requirement_index: 1.5.06
     statement: You must give each user of the TRE a unique logon with changes to
       any records strictly controlled.
     guidance:
@@ -369,7 +369,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.1
+    requirement_index: 1.6.01
     statement: You must determine what training is relevant for all roles within
       the TRE organisation.
     guidance:
@@ -383,7 +383,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.2
+    requirement_index: 1.6.02
     statement: You must ensure that relevant training is available for all roles
       within the TRE organisation.
     guidance:
@@ -396,7 +396,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.3
+    requirement_index: 1.6.03
     statement: You must provide repeat or updated training where necessary to
       account for changes in competency requirements.
     guidance:
@@ -409,7 +409,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.4
+    requirement_index: 1.6.04
     statement: You must maintain accurate training records that are directly
       tied to the role and access levels within the TRE.
     guidance:
@@ -421,7 +421,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.5
+    requirement_index: 1.6.05
     statement: You should accept proof of relevant training certifications from
       trusted third parties.
     guidance: You might choose to trust certifications provided by known
@@ -431,7 +431,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.6
+    requirement_index: 1.6.06
     statement: You could have a training platform capable of delivering online
       training in a variety of formats.
     guidance:
@@ -443,7 +443,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.7
+    requirement_index: 1.6.07
     statement: You could implement a learning management system (LMS) to manage
       courses and deliver training as required.
     guidance: Where possible an LMS should support a variety of course content
@@ -453,7 +453,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.8
+    requirement_index: 1.6.08
     statement: You could ensure that any courses you use are available in
       standard, transferable formats.
     guidance:
@@ -465,7 +465,7 @@ specification:
   - pillar: Information governance
     capability: Training Management and Delivery
     capability_index: "1.6"
-    requirement_index: 1.6.9
+    requirement_index: 1.6.09
     statement: You could keep historical copies of courses in order to
       demonstrate competency at a given point in time.
     guidance:
@@ -478,7 +478,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.1
+    requirement_index: 2.1.01
     statement: You must not allow users to copy data out of your TRE via the
       system clipboard.
     guidance:
@@ -491,7 +491,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.2
+    requirement_index: 2.1.02
     statement: Your TRE workspace should provide an environment familiar to your
       users.
     guidance:
@@ -504,7 +504,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.3
+    requirement_index: 2.1.03
     statement: A TRE could restrict data access from data consumers entirely and
       provide an interface for submitting code.
     guidance: For example, you might use a system where users submit jobs that
@@ -514,7 +514,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.4
+    requirement_index: 2.1.04
     statement: Your TRE should be accessed via a user interface accessible using
       commonly available applications.
     guidance:
@@ -526,7 +526,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.5
+    requirement_index: 2.1.05
     statement: Your TRE must provide clear guidance on how to use software tools
       and work with data in the TRE.
     guidance:
@@ -540,7 +540,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.6
+    requirement_index: 2.1.06
     statement: Your TRE should, where possible, automatically apply security
       related updates for user software.
     guidance: Reducing the risk of exploitable vulnerabilities in installed
@@ -550,7 +550,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.7
+    requirement_index: 2.1.07
     statement: Your TRE could provide shared services that are accessible to
       users in the same project.
     guidance:
@@ -562,7 +562,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.8
+    requirement_index: 2.1.08
     statement: Your TRE must ensure that any shared services are only available
       to users working on the same project.
     guidance:
@@ -574,7 +574,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: End User Computing
     capability_index: "2.1"
-    requirement_index: 2.1.9
+    requirement_index: 2.1.09
     statement: You must mitigate and record any risks introduced by the use in
       your TRE of software that requires telemetry to function.
     guidance:
@@ -703,7 +703,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.1
+    requirement_index: 2.2.01
     statement: You must have a documented procedure for deploying
       infrastructure.
     guidance: This might, for instance, be a handbook that is followed or a set
@@ -713,7 +713,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.2
+    requirement_index: 2.2.02
     statement: You should, where possible, automate any repeatable aspects of
       your deployment.
     guidance: This might involve using infrastructure-as-code tools or a series
@@ -723,7 +723,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.3
+    requirement_index: 2.2.03
     statement: You must have a documented procedure for making changes to
       deployed infrastructure.
     guidance:
@@ -735,7 +735,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.4
+    requirement_index: 2.2.04
     statement: You must test changes before they are used in production.
     guidance: This might involve a separate development environment or another
       system for testing.
@@ -744,7 +744,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.5
+    requirement_index: 2.2.05
     statement: You should have a development environment that mirrors your
       production environment which you use to test infrastructure changes before
       committing them to production.
@@ -757,7 +757,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.6
+    requirement_index: 2.2.06
     statement: You must have a documented procedure for removing infrastructure
       when it is no longer needed.
     guidance: Removing unused infrastructure not only reduces costs and
@@ -768,7 +768,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.7
+    requirement_index: 2.2.07
     statement: You should understand the availability and uptime guarantees of
       any providers that you rely on.
     guidance:
@@ -780,7 +780,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.8
+    requirement_index: 2.2.08
     statement: You should develop an availability target or statement and share
       this with your users.
     guidance: Understanding how and when the TRE might be unavailable will help
@@ -790,7 +790,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Infrastructure Management
     capability_index: "2.2"
-    requirement_index: 2.2.9
+    requirement_index: 2.2.09
     statement: Your TRE must control and manage all of its network
       infrastructure in order to protect information in systems and
       applications.
@@ -871,7 +871,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Capacity Management
     capability_index: "2.3"
-    requirement_index: 2.3.1
+    requirement_index: 2.3.01
     statement: You must ensure that all projects understand what resources are
       available and what the associated costs will be before the project starts.
     guidance:
@@ -884,7 +884,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Capacity Management
     capability_index: "2.3"
-    requirement_index: 2.3.2
+    requirement_index: 2.3.02
     statement: You should ensure that the anticipated needs of projects can be
       satisfied using available resources.
     guidance: Note that this does not require you to accept requests for
@@ -895,7 +895,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Capacity Management
     capability_index: "2.3"
-    requirement_index: 2.3.3
+    requirement_index: 2.3.03
     statement: You must have a procedure for allocating available resources
       among projects.
     guidance:
@@ -910,7 +910,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Capacity Management
     capability_index: "2.3"
-    requirement_index: 2.3.4
+    requirement_index: 2.3.04
     statement: You must ensure that the anticipated resource requirements will
       not result in overspending by the TRE.
     guidance:
@@ -922,7 +922,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Configuration Management
     capability_index: "2.4"
-    requirement_index: 2.4.1
+    requirement_index: 2.4.01
     statement: You must have a documented procedure for configuring
       infrastructure.
     guidance: This might, for instance, be a handbook that is followed or a set
@@ -932,7 +932,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Configuration Management
     capability_index: "2.4"
-    requirement_index: 2.4.2
+    requirement_index: 2.4.02
     statement: You should use configuration management tools to automate
       application of your configuration wherever possible.
     guidance: This might involve configuration-as-code tools such as Ansible,
@@ -943,7 +943,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Configuration Management
     capability_index: "2.4"
-    requirement_index: 2.4.3
+    requirement_index: 2.4.03
     statement: You should be able to verify whether the configuration is valid.
     guidance: This might, for instance, involve running your configuration
       management tool in ‘check’ mode.
@@ -952,7 +952,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Configuration Management
     capability_index: "2.4"
-    requirement_index: 2.4.4
+    requirement_index: 2.4.04
     statement: You should regularly verify your TRE configuration.
     guidance: This will limit the amount of time the TRE can spend in a
       non-compliant state.
@@ -961,7 +961,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Configuration Management
     capability_index: "2.4"
-    requirement_index: 2.4.5
+    requirement_index: 2.4.05
     statement: You must be able to replace a non-compliant TRE with a compliant
       system.
     guidance: This might involve reconfiguring a running system or by replacing
@@ -971,7 +971,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.1
+    requirement_index: 2.5.01
     statement: You should keep backups of data and research environments,
       provided that this is permitted by law.
     guidance:
@@ -984,7 +984,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.2
+    requirement_index: 2.5.02
     statement: You should build redundancy into infrastructure and storage.
     guidance:
       "Infrastructure should be as resilient as necessary to interruption.\n\
@@ -995,7 +995,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.3
+    requirement_index: 2.5.03
     statement: You should keep backups of infrastructure, applications and
       configurations.
     guidance: This may include virtualised infrastructure snapshots which can
@@ -1005,7 +1005,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.4
+    requirement_index: 2.5.04
     statement: You must have procedures in place for rapid incident response.
     guidance:
       "There may be legal requirements to disclose details of any incidents,
@@ -1016,7 +1016,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.5
+    requirement_index: 2.5.05
     statement: You should test your incident response through simulation.
     guidance:
       "During simulated incidents the TRE organisation can measure their effectiveness.\n\
@@ -1026,7 +1026,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.6
+    requirement_index: 2.5.06
     statement: You should have an application in place to scan for
       vulnerabilities across infrastructure.
     guidance:
@@ -1037,7 +1037,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.7
+    requirement_index: 2.5.07
     statement: You must have a process in place for applying security updates to
       all software that forms part of the TRE infrastructure.
     guidance: This includes any software used for remote desktop portals,
@@ -1048,7 +1048,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.8
+    requirement_index: 2.5.08
     statement: Infrastructure should be automatically patched for
       vulnerabilities.
     guidance:
@@ -1061,7 +1061,7 @@ specification:
   - pillar: Computing technology and Information Security
     capability: Information Security
     capability_index: "2.5"
-    requirement_index: 2.5.9
+    requirement_index: 2.5.09
     statement: You should carry out penetration tests on your TRE.
     guidance:
       "By intentionally attempting to breach their TRE, organisations can
@@ -1187,7 +1187,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.1
+    requirement_index: 3.1.01
     statement: You must have processes in place to assess the legal and
       regulatory implications of handling the data through its full lifecycle.
     guidance:
@@ -1201,7 +1201,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.2
+    requirement_index: 3.1.02
     statement: You should keep records of data handling decisions.
     guidance: Decisions that are made as part of the process discussed above
       should be recorded and made available for inspection by all stakeholders.
@@ -1210,7 +1210,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.3
+    requirement_index: 3.1.03
     statement: Information asset owners must classify data sets according to a
       common process and data classification methodology.
     guidance:
@@ -1224,7 +1224,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.4
+    requirement_index: 3.1.04
     statement: You must have a data ingress process which enforces information
       governance rules/processes.
     guidance:
@@ -1236,7 +1236,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.5
+    requirement_index: 3.1.05
     statement: You must have a data egress process which enforces information
       governance rules/processes.
     guidance:
@@ -1248,7 +1248,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.6
+    requirement_index: 3.1.06
     statement: Egress must be limited to the information asset owners or their
       delegates.
     guidance:
@@ -1260,7 +1260,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.7
+    requirement_index: 3.1.07
     statement: Your data egress process could sometimes require
       project-independent approval.
     guidance:
@@ -1273,7 +1273,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.8
+    requirement_index: 3.1.08
     statement: You must keep a record of what data your TRE holds.
     guidance:
       "Good records are important for ensuring compliance with legislation,
@@ -1286,7 +1286,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.1"
-    requirement_index: 3.1.9
+    requirement_index: 3.1.09
     statement: You must have a policy on data deletion.
     guidance:
       "There should be a clear, published policy on when data will be retained
@@ -1350,7 +1350,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.1
+    requirement_index: 3.2.01
     statement: You must not create user accounts for use by more than one
       person.
     guidance: It is important that each user account should be used by one, and
@@ -1361,7 +1361,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.2
+    requirement_index: 3.2.02
     statement: You must be reasonably convinced of the identity of each person
       being granted an account.
     guidance:
@@ -1373,7 +1373,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.3
+    requirement_index: 3.2.03
     statement: You must restrict a user’s access to only data required in their
       work.
     guidance:
@@ -1385,7 +1385,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.4
+    requirement_index: 3.2.04
     statement: You must ensure that multi-factor authentication is enabled for
       all users.
     guidance:
@@ -1400,7 +1400,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.5
+    requirement_index: 3.2.05
     statement: You could use federated authentication or single sign-on (SSO)
       for user login.
     guidance:
@@ -1413,7 +1413,7 @@ specification:
   - pillar: Data management
     capability: Identity and Access Management
     capability_index: "3.2"
-    requirement_index: 3.2.6
+    requirement_index: 3.2.06
     statement: You could restrict access to particular networks or physical
       locations.
     guidance:
@@ -1425,7 +1425,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.1
+    requirement_index: 3.3.01
     statement: You should have a system to help classify outputs.
     guidance:
       "Removing data from a TRE can be a difficult process as there is potential
@@ -1438,7 +1438,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.2
+    requirement_index: 3.3.02
     statement: You should establish the intended outputs of each project from
       the outset.
     guidance:
@@ -1452,7 +1452,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.3
+    requirement_index: 3.3.03
     statement: You must have a documented process for disclosure control of
       outputs from the TRE.
     guidance:
@@ -1464,7 +1464,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.4
+    requirement_index: 3.3.04
     statement: You must have a process for assigning responsibility for output
       checking.
     guidance:
@@ -1477,7 +1477,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.5
+    requirement_index: 3.3.05
     statement: You must have a documented policy for handling disclosure risks
       associated with any outputs that cannot be manually checked.
     guidance:
@@ -1490,7 +1490,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.6
+    requirement_index: 3.3.06
     statement: You should have a statistical basis to guide the decisions of an
       output checker on the safety of outputs.
     guidance: There should be a solid basis to allow decisions to be made about
@@ -1501,7 +1501,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.7
+    requirement_index: 3.3.07
     statement: You could create a semi-automated system for checks on common
       research outputs.
     guidance:
@@ -1514,7 +1514,7 @@ specification:
   - pillar: Data management
     capability: Output Management
     capability_index: "3.3"
-    requirement_index: 3.3.8
+    requirement_index: 3.3.08
     statement: TRE outputs should be limited to the minimum required for sharing
       results of any analyses.
     guidance: This decreases the risk of inadvertent disclosure, and makes it
@@ -1524,7 +1524,7 @@ specification:
   - pillar: Data management
     capability: Information search and discovery
     capability_index: "3.4"
-    requirement_index: 3.4.1
+    requirement_index: 3.4.01
     statement: You should provide a metadata catalogue of available datasets for
       users.
     guidance:
@@ -1537,7 +1537,7 @@ specification:
   - pillar: Data management
     capability: Security Levels and Tiering
     capability_index: "3.5"
-    requirement_index: 3.5.1
+    requirement_index: 3.5.01
     statement: You must be able to specify what categories of data your TRE is
       able to support.
     guidance:
@@ -1550,7 +1550,7 @@ specification:
   - pillar: Data management
     capability: Security Levels and Tiering
     capability_index: "3.5"
-    requirement_index: 3.5.2
+    requirement_index: 3.5.02
     statement: Your TRE could support projects with differing security
       requirements through configurable security controls.
     guidance:
@@ -1562,7 +1562,7 @@ specification:
   - pillar: Data management
     capability: Security Levels and Tiering
     capability_index: "3.5"
-    requirement_index: 3.5.3
+    requirement_index: 3.5.03
     statement: Your TRE could offer a pre-defined set of security control tiers.
     guidance:
       "Security control tiers can be designed to cover the types of project
@@ -1574,7 +1574,7 @@ specification:
   - pillar: Data management
     capability: Research Meta-Data
     capability_index: "3.6"
-    requirement_index: 3.6.1
+    requirement_index: 3.6.01
     statement: You should have a consistent and easily accessible meta-data data
       model or similar to describe what a data asset contains.
     guidance:
@@ -1587,7 +1587,7 @@ specification:
   - pillar: Data management
     capability: Research Meta-Data
     capability_index: "3.6"
-    requirement_index: 3.6.2
+    requirement_index: 3.6.02
     statement: You could provide summary, abstracted or synthetic data to
       researchers without exposing the underlying data set.
     guidance: To reduce the need for access to row level data researchers could
@@ -1599,7 +1599,7 @@ specification:
   - pillar: Data management
     capability: Meta-Data Search and Discovery Application
     capability_index: "3.7"
-    requirement_index: 3.7.1
+    requirement_index: 3.7.01
     statement: You could provide an interface application for data consumers and
       data subjects to query elements of the data.
     guidance: In order to make data findable, an application which queries the
@@ -1610,7 +1610,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.8"
-    requirement_index: 3.8.1
+    requirement_index: 3.8.01
     statement: Archived data within the TRE should be read only.
     guidance:
       "Archived data by its very nature should not change and therefore be
@@ -1621,7 +1621,7 @@ specification:
   - pillar: Data management
     capability: Data Lifecycle Management
     capability_index: "3.8"
-    requirement_index: 3.8.2
+    requirement_index: 3.8.02
     statement: Long-term archives must be held in simple, standard formats to
       ensure accessibility.
     guidance:
@@ -1634,7 +1634,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Business Continuity
     capability_index: "4.1"
-    requirement_index: 4.1.1
+    requirement_index: 4.1.01
     statement: You should have a business continuity plan that includes
       consideration of loss of service for deployed TREs.
     guidance:
@@ -1646,7 +1646,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Business Continuity
     capability_index: "4.1"
-    requirement_index: 4.1.2
+    requirement_index: 4.1.02
     statement: You should regularly test the aspects of your business continuity
       plan concerning TREs, and have a process in place to iterate the plan if
       required.
@@ -1656,7 +1656,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Projectect and Programme Management
     capability_index: "4.2"
-    requirement_index: 4.2.1
+    requirement_index: 4.2.01
     statement: You should ensure that all projects using your TRE have a named
       project manager.
     guidance:
@@ -1669,7 +1669,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Projectect and Programme Management
     capability_index: "4.2"
-    requirement_index: 4.2.2
+    requirement_index: 4.2.02
     statement: You should not give project managers direct access to the TRE.
     guidance: Doing so ensures a separation between those able to access
       sensitive data, and those overseeing access to sensitive data.
@@ -1678,7 +1678,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Knowledge Management
     capability_index: "4.3"
-    requirement_index: 4.3.1
+    requirement_index: 4.3.01
     statement: You must document all features of your TRE implementation.
     guidance: This includes ensuring all documentation is discoverable, clear,
       and able to be easily updated based on stakeholder feedback
@@ -1687,7 +1687,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Knowledge Management
     capability_index: "4.3"
-    requirement_index: 4.3.2
+    requirement_index: 4.3.02
     statement: You should have an education programme in place to upskill
       stakeholders in the use and management of your TRE.
     guidance: This may include learning modules, workshops and other resources
@@ -1698,7 +1698,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Knowledge Management
     capability_index: "4.3"
-    requirement_index: 4.3.3
+    requirement_index: 4.3.03
     statement: You should periodically carry out a training needs analysis (TNA)
       for all stakeholders included within your TRE provision.
     guidance: At least once every 12 months you should assess the training needs
@@ -1709,7 +1709,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Financial Management
     capability_index: "4.4"
-    requirement_index: 4.4.1
+    requirement_index: 4.4.01
     statement: You must ensure that all projects using your TRE are aware of any
       associated costs and are able and willing to pay them.
     guidance: Costs may include provision of the underlying TRE infrastructure,
@@ -1721,7 +1721,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Financial Management
     capability_index: "4.4"
-    requirement_index: 4.4.2
+    requirement_index: 4.4.02
     statement: You should be able to track the costs associated with each TRE
       project.
     guidance: This includes knowing which costs are associated with which
@@ -1732,7 +1732,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Financial Management
     capability_index: "4.4"
-    requirement_index: 4.4.3
+    requirement_index: 4.4.03
     statement: You should have a process in place to ensure your TRE provision
       remains financially sustainable.
     guidance:
@@ -1745,7 +1745,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Financial Management
     capability_index: "4.4"
-    requirement_index: 4.4.4
+    requirement_index: 4.4.04
     statement: You should minimise the cost of your TRE infrastructure wherever
       possible
     guidance: You should have regular reviews of your TRE provision and actively
@@ -1755,7 +1755,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Procurement
     capability_index: "4.5"
-    requirement_index: 4.5.1
+    requirement_index: 4.5.01
     statement: You must identify any goods or services that will be needed to
       operate the TRE and ensure that a plan is in place to purchase them as
       needed.
@@ -1766,7 +1766,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: IT Service Management
     capability_index: "4.6"
-    requirement_index: 4.6.1
+    requirement_index: 4.6.01
     statement: Your TRE must have a team of Operators in place to support
       projects working with TREs.
     guidance:
@@ -1778,7 +1778,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Relationship Management
     capability_index: "4.7"
-    requirement_index: 4.7.1
+    requirement_index: 4.7.01
     statement: You should have a clear process in place for stakeholders to
       feedback on your TRE infrastructure.
     guidance: This may include a GitHub repository where people can open issues
@@ -1789,7 +1789,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Public Involvement and Engagement
     capability_index: "4.8"
-    requirement_index: 4.8.1
+    requirement_index: 4.8.01
     statement: All public engagement activities must include a range of
       perspectives and be inclusive (*optional for TREs without personal data).
     guidance:
@@ -1803,7 +1803,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Public Involvement and Engagement
     capability_index: "4.8"
-    requirement_index: 4.8.2
+    requirement_index: 4.8.02
     statement: Details of TRE operations, data available and projects which have
       accessed the data should be publicly available (*optional for TREs without
       personal data).
@@ -1819,7 +1819,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Public Involvement and Engagement
     capability_index: "4.8"
-    requirement_index: 4.8.3
+    requirement_index: 4.8.03
     statement: Members of the public should be included in TRE operations and/or
       oversight (*optional for TREs without personal data).
     guidance:
@@ -1831,7 +1831,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Public Involvement and Engagement
     capability_index: "4.8"
-    requirement_index: 4.8.4
+    requirement_index: 4.8.04
     statement: You should publicly share details of incidents, near misses, and
       mitigations in a timely fashion, in line with good practices for
       responsible disclosure.
@@ -1843,7 +1843,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Legal Services
     capability_index: "4.9"
-    requirement_index: 4.9.1
+    requirement_index: 4.9.01
     statement: You should identify areas where legal advice may be required and
       ensure that you have ready access to it.
     guidance:
@@ -1856,7 +1856,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Legal Services
     capability_index: "4.9"
-    requirement_index: 4.9.2
+    requirement_index: 4.9.02
     statement: You should identify areas where advice on data protection issues
       may be required and ensure that you have ready access to it.
     guidance: It is likely that data protection advice will be necessary for
@@ -1866,7 +1866,7 @@ specification:
   - pillar: Supporting Capabilities
     capability: Legal Services
     capability_index: "4.9"
-    requirement_index: 4.9.3
+    requirement_index: 4.9.03
     statement: You should identify who will be responsible for managing
       contracts related to the TRE.
     guidance: These contracts may include data sharing agreements, secondments
@@ -1874,3 +1874,275 @@ specification:
       distributed.
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-f28b720cce80472ebb8aeb05b2ba6954
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.01
+    statement: The federation must define a scope and governance structure for
+      the federation made up of member TREs and interested parties.
+    guidance:
+      "A federation may have 2 levels of management with top management
+      making decisions around risk, and resources with an operation group making
+      day-to-day decisions related to the running of the federation.\n\nInterested
+      parties might include PPIE, Data Providers, member TRE operators etc.\n\nEstablish
+      best-practice decision-making processes that ensure all stakeholders have an
+      equal opportunity to contribute, underpinned by a commitment to transparency
+      and meaningful public representation at every stage."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.02
+    statement: The federation must define key roles (individual and group) and
+      agree a shared responsibility model for the federation.
+    guidance:
+      "Define a responsibility framework for different individual and group
+      roles. This defines when the authority rests with a central federation body
+      versus with individual members. Key roles might include TRE provider organisation,
+      infrastructure provider, researcher, top management etc.\n\nA document covering
+      responsibilities assigned to these roles could include RACI or be based on established
+      model such as those used by public cloud providers.\n\nExample of key roles
+      can be found here: https://satre-specification.readthedocs.io/en/latest/roles.html\n\
+      \nRelated 1.3.4"
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.03
+    statement: The federation must agree a standard set of rules required for
+      each member TRE. Member TREs must make their compliance status with these
+      rules available for audit by the federation, other members and external
+      parties as appropriate.
+    guidance:
+      "Standards and rules expected or required by the federation may be
+      specific to the federation or require meeting external standards (EG. SATRE,
+      DSPT, ISO 27001,CAF)  these should be tracked and be accessible by the federation
+      and it's members.\n\nThese rules are likely to be a mix of high-level organisational
+      requirements and specific controls."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.2"
+    requirement_index: 5.1.04
+    statement: Federation members must share any relevant incident, audit and
+      other quality management data with members.
+    guidance: While organisations may not share all such details widely any
+      information that has a potential effect on other member TREs or the
+      federation as a whole must be shared.
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.05
+    statement: The federation must agree a process to create, update and retire
+      rules formal rules and standard operating procedures and make them
+      available to TRE members.
+    guidance:
+      "Some shared processes will be critical to the operation of the federation
+      such as data access requests, data classification, output checking and release,
+      project initiation and termination. There must be a process to implementing,
+      changing and removing such processes.\n\nThis ensures decisions are portable
+      across federation (EG. output approved in one TRE is recognized by others)"
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.06
+    statement: The federation must define processes for TREs joining and leaving
+      the federation
+    guidance:
+      "Federations may be long-standing and stable or short lived and project
+      based the processes should reflect the impact of a member TRE joining/leaving.
+      The federation may include passive or default processes, like removal through
+      inactivity or non-compliance.\n\nThese processes should include the credential
+      management /revocation etc."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.07
+    statement: The federation should agree a consistent approach to risk
+      assessment and treatment. Where multiple approaches are used equivalence
+      must be established.
+    guidance: It is likely that different organisations will have different risk
+      matrices and risk tolerance. The federation should assess combined risk,
+      treat where possible and accept any residual risk.
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.08
+    statement: The federation should agree standard terminology for use in
+      agreements and documentation with a glossary as needed.
+    guidance: Where possible organisations should re-use of existing glossaries
+      such as https://glossary.uktre.org/
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.09
+    statement: Access requests to the federation should use common or single
+      templates for legal or administration purposes.
+    guidance:
+      "Examples of standard agreements are Data Protection Impact Assessment,
+      Collaboration agreements, researcher access agreements.\n\nShould be managed
+      by the \"Front Door\" node."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Federation Governance
+    capability_index: "5.1"
+    requirement_index: 5.1.10
+    statement: Where federation involves members of the public there should be
+      representation from across all member TREs areas
+    guidance:
+      "When moving from a single TRE to a federation it is important to
+      consider public representation coving data across the entire federation. This
+      is especially relevant for where member TREs cover different populations (e.g.
+      regions, counties) or data domains (e.g. Health, financial data)."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
+  - pillar: Federation
+    capability: Member Accreditation
+    capability_index: "5.3"
+    requirement_index: 5.2.01
+    statement: The federation must agree baseline competency requirements for
+      all users.
+    guidance:
+      "Competency ensures a consistent definition of a \"Safe Researcher\".
+      Ideally all federations use an existing registry such as https://safepeopleregistry.org/en.
+      Alternatively, standardised training could be provided by the federation or
+      multiple trainings could be acceptable. Training status of users should be accessible
+      programmatically by all member TREs."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-member-accreditation
+  - pillar: Federation
+    capability: Federation Study Management
+    capability_index: "5.4"
+    requirement_index: 5.3.01
+    statement: The federation must maintain a register of "Safe Projects"
+    guidance:
+      "The project register should be accessible programmatically by all
+      member TREs, good practice to make it available to public."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
+  - pillar: Federation
+    capability: Federation Study Management
+    capability_index: "5.4"
+    requirement_index: 5.3.02
+    statement: The federation must agree the legal, ethical and compliance
+      standards required for a safe federated project.
+    guidance:
+      "All central registries of projects must adhere to agreed data standards
+      and be accessible as needed by federation members.\nHDR UK provide recommendations
+      for a data use registry as a  guide\nhttps://zenodo.org/records/5902743#.YfAI__7P2Uk"
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
+  - pillar: Federation
+    capability: Federation Information Security
+    capability_index: "5.5"
+    requirement_index: 5.4.01
+    statement: The federation must implement network-level standards for
+      cryptographic key and secrets management.
+    guidance: Automated secrets management
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
+  - pillar: Federation
+    capability: Federation Information Security
+    capability_index: "5.5"
+    requirement_index: 5.5.02
+    statement: The federation must define and agree, implement and regularly
+      test a shared incident response process.
+    guidance:
+      "a federation wide incident response process should cover incidents
+      affecting member TREs, the federation and federation projects and include confidentiality,
+      integrity and availability.\n\nExamples of such incidents are data quality
+      issues or availability or data at  a member TRE."
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
+  - pillar: Federation
+    capability: Federation Information Security
+    capability_index: "5.5"
+    requirement_index: 5.5.03
+    statement: The federation should support a common user and machine
+      identities with a defined set of attributes for use across the federation.
+    guidance: Identity provider federation with agreed, shared attributes for
+      each user or machine identities.
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
+  - pillar: Federation
+    capability: Federation Information Security
+    capability_index: "5.5"
+    requirement_index: 5.5.04
+    statement: The federation could use threat modelling definition to identify
+      areas of risk to infrastructure.
+    guidance:
+      "Understanding cross threat across multiple organisations may be challenging.
+      Threat modelling provides a structured process for members TREs to discuss and
+      assess threats across a federation.\n\nInformation on threat models here:\nhttps://owasp.org/www-community/Threat_Modeling"
+    importance: Optional
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
+  - pillar: Federation
+    capability: Federation Information Security
+    capability_index: "5.5"
+    requirement_index: 5.5.06
+    statement: Shared federation services must maintain security logs of events
+      including authentication and data transfer.
+    guidance: The federation should implement shared visibility of security logs
+      where appropriate for federation-wide threat detection.
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
+  - pillar: Federation
+    capability: Federation Infrastructure management
+    capability_index: "5.6"
+    requirement_index: 5.6.01
+    statement: Federation members must maintain accurate configuration
+      information on federation services and make it available to appropriate
+      parties.
+    guidance: Examples would be access to code repositories used to deploy
+      shared infrastructure or network routing and firewall information for
+      federation network traffic.
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-infrastructure-management
+  - pillar: Federation
+    capability: Federation Data Management
+    capability_index: "5.7"
+    requirement_index: 5.7.01
+    statement: The federation must implement a single, consistent output
+      classification (definition of a safe output)
+    guidance:
+      "Output rule must cover data moving between federation members (outputs
+      from a TRE to the next environment) and research outputs suitable for transfer
+      out of a member TRE.\n\nCheck PIE statement to the right"
+    importance: Mandatory
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-data-management
+  - pillar: Federation
+    capability: Federation Data Management
+    capability_index: "5.7"
+    requirement_index: 5.7.02
+    statement: The Federation should provide searchable catalogue(s) of metadata
+      describing data assets across federation members
+    guidance:
+      "Metadata catalogues describing data across a federation should support
+      semantic searches across diverse data types.\nThe Federation should agree a
+      minimum level of metadata completeness."
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-data-management
+  - pillar: Federation
+    capability: Federation Financial Management
+    capability_index: "5.8"
+    requirement_index: 5.8.01
+    statement: The federation should agree a pricing model for federation
+      projects.
+    guidance: A consistent charging mechanism prevents differential charging and
+      competition between member TREs for similar data.
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-financial-management

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -2044,7 +2044,7 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
   - pillar: Federation
     capability: Federation Information Security
-    capability_index: "5.5"
+    capability_index: "5.4"
     requirement_index: 5.4.01
     statement: The federation must implement network-level standards for
       cryptographic key and secrets management.
@@ -2053,8 +2053,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Information Security
-    capability_index: "5.5"
-    requirement_index: 5.5.02
+    capability_index: "5.4"
+    requirement_index: 5.4.02
     statement: The federation must define and agree, implement and regularly
       test a shared incident response process.
     guidance:
@@ -2066,8 +2066,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Information Security
-    capability_index: "5.5"
-    requirement_index: 5.5.03
+    capability_index: "5.4"
+    requirement_index: 5.4.03
     statement: The federation should support common user and machine
       identities with a defined set of attributes for use across the federation.
     guidance: Identity provider federation with agreed, shared attributes for
@@ -2076,8 +2076,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Information Security
-    capability_index: "5.5"
-    requirement_index: 5.5.04
+    capability_index: "5.4"
+    requirement_index: 5.4.04
     statement: The federation could use threat modelling definition to identify
       areas of risk to infrastructure.
     guidance:
@@ -2088,8 +2088,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Information Security
-    capability_index: "5.5"
-    requirement_index: 5.5.06
+    capability_index: "5.4"
+    requirement_index: 5.4.06
     statement: Shared federation services must maintain security logs of events
       including authentication and data transfer.
     guidance: The federation should implement shared visibility of security logs
@@ -2098,8 +2098,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-information-security
   - pillar: Federation
     capability: Federation Infrastructure management
-    capability_index: "5.6"
-    requirement_index: 5.6.01
+    capability_index: "5.5"
+    requirement_index: 5.5.01
     statement: Federation members must maintain accurate configuration
       information on federation services and make it available to appropriate
       parties.
@@ -2110,8 +2110,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-infrastructure-management
   - pillar: Federation
     capability: Federation Data Management
-    capability_index: "5.7"
-    requirement_index: 5.7.01
+    capability_index: "5.6"
+    requirement_index: 5.6.01
     statement: The federation must implement a single, consistent output
       classification (definition of a safe output)
     guidance:
@@ -2122,8 +2122,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-data-management
   - pillar: Federation
     capability: Federation Data Management
-    capability_index: "5.7"
-    requirement_index: 5.7.02
+    capability_index: "5.6"
+    requirement_index: 5.6.02
     statement: The Federation should provide searchable catalogue(s) of metadata
       describing data assets across federation members
     guidance:
@@ -2134,8 +2134,8 @@ specification:
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-data-management
   - pillar: Federation
     capability: Federation Financial Management
-    capability_index: "5.8"
-    requirement_index: 5.8.01
+    capability_index: "5.7"
+    requirement_index: 5.7.01
     statement: The federation should agree a pricing model for federation
       projects.
     guidance: A consistent charging mechanism prevents differential charging and

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -1,6 +1,6 @@
 # The SATRE Specification
 
-The SATRE specification is organized into five core pillars that cover all aspects of TRE provision:
+The SATRE specification is organized into four core pillars that cover all aspects of TRE provision, with an additional fifth pillar for TREs wishing to federate.
 
 **Jump to a pillar:**
 
@@ -8,7 +8,7 @@ The SATRE specification is organized into five core pillars that cover all aspec
 - [Computing technology and Information Security](#computing-technology-and-information-security)
 - [Data management](#data-management)
 - [Supporting capabilities](#supporting-capabilities)
-- [Federation](#federation)
+- [Federation](#federation) _(extension for federated TREs)_
 
 ---
 

--- a/docs/source/specification.md
+++ b/docs/source/specification.md
@@ -1,6 +1,6 @@
 # The SATRE Specification
 
-The SATRE specification is organized into four core pillars that cover all aspects of TRE provision:
+The SATRE specification is organized into five core pillars that cover all aspects of TRE provision:
 
 **Jump to a pillar:**
 
@@ -8,6 +8,7 @@ The SATRE specification is organized into four core pillars that cover all aspec
 - [Computing technology and Information Security](#computing-technology-and-information-security)
 - [Data management](#data-management)
 - [Supporting capabilities](#supporting-capabilities)
+- [Federation](#federation)
 
 ---
 


### PR DESCRIPTION
## Release SATRE Specification v2.0

This PR releases v2.0 of the SATRE specification. The headline change is the addition of a new **Federation pillar** — 21 new statements covering what it means for TREs to operate as part of a federated network. Alongside that, several structural improvements have been made to the existing pillars, most notably moving PPIE into Information Governance where it belongs.

The specification now contains **182 statements** across **5 pillars** (up from 160 across 4).

Resolves #465 #478 #479 #487 #488 #483 #485 #486 #489 #451 #501

---

### Specification structure (v2.0)

| Pillar | Capabilities | Statements |
|---|---|---|
| 1. Information Governance | 7 | 46 |
| 2. Computing Technology and Information Security | 5 | 62 |
| 3. Data Management | 7 | 36 |
| 4. Supporting Capabilities | 8 | 17 |
| 5. Federation *(new)* | 7 | 21 |

---

### What's changed

#### New: Pillar 5 — Federation

The major addition in this release. Pillar 5 defines requirements for TREs operating as members of a federation — a group of TREs with shared governance, standards, and (potentially) shared infrastructure or data access.

The pillar has 7 capabilities:

- **5.1 Federation Governance** (10 statements) — Scope and governance structure, shared responsibility models, agreed membership standards with auditable compliance, incident/audit data sharing between members, change procedures for federation rules, and join/leave processes. Includes a `Mandatory*` requirement for public representation across the full federation where personal data is involved.
- **5.2 Member Accreditation** (1 statement) — Baseline competency requirements (e.g. safe researcher training) agreed across all member TREs.
- **5.3 Federation Study Management** (2 statements) — A federation-wide register of Safe Projects (API-accessible), and agreed legal/ethical/compliance standards for federated projects.
- **5.4 Federation Information Security** (4 statements) — Shared cryptographic standards, a federation-wide incident response process, common identity attributes across members, and shared security log visibility.
- **5.5 Federation Infrastructure Management** (1 statement) — Members must maintain and share accurate configuration information on federation services.
- **5.6 Federation Data Management** (2 statements) — An agreed definition of a safe output covering both TRE-to-TRE transfers and outputs leaving the federation; a searchable, cross-federation metadata catalogue.
- **5.7 Federation Financial Management** (1 statement) — A consistent pricing model for federation projects.

---

#### PPIE moved into Information Governance (capability 1.7)

The four Public Involvement and Engagement statements have moved from Supporting Capabilities (previously 4.8) into a new capability **1.7** within the Information Governance pillar. This reflects PPIE being a core governance obligation, not an operational nice-to-have. Statement content is unchanged; indices change from `4.8.01–04` to `1.7.01–04`.

---

#### Archive statements consolidated into Data Lifecycle Management

Two statements previously sitting in a standalone capability 3.8 have been pulled into the main **3.1 Data Lifecycle Management** capability as `3.1.14` and `3.1.15`. The content is unchanged — this removes an unnecessary structural split within the Data Management pillar.

---

#### New statement: threat modelling (2.5.19)

A single new `Optional` statement added to Information Security: *"Your TRE could use threat modelling to identify areas of risk to infrastructure."* Guidance references OWASP threat modelling resources.

---

#### Requirement index format standardised

All requirement indices are now **zero-padded to two digits** throughout (e.g. `1.1.1` → `1.1.01`). This is a systematic format change with no effect on statement content. **If you reference specific indices in external documentation or tooling, these will need updating.**

---

#### Improved readability on wide screens

Added a custom CSS override to widen the documentation content area:

```css
.wy-nav-content {
  max-width: 1200px;
}
```

The default ReadTheDocs theme caps content width at 800px, which makes the specification awkward to read — particularly the longer statement and guidance fields. This raises the limit to 1200px, making better use of screen space without affecting layout on smaller displays.

---

#### Minor fixes

- **Duplicate statement corrected**: In v1.1, a Quality Management statement was incorrectly numbered `1.1.2` (an Information Governance index) rather than `1.2.2`. This is fixed — it now sits correctly at `1.2.02`.
- **Typo fixed**: Capability 4.2 was named "Projectect and Programme Management". Now corrected to "Project and Programme Management".
