### PR TITLE
minor changes to wording

### DIFF
--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1894,7 +1894,7 @@ specification:
     guidance: "A federation may have 2 levels of management with top management
       making decisions around risk, and resources with an operation group making
       day-to-day decisions related to the running of the federation.\n\nInterested
-      parties might include PPIE, Data Providers, member TRE operators etc.\n\nEstablish
+      parties might include PPIE, Data Providers, member TRE operators and external oversight etc.\n\nEstablish
       best-practice decision-making processes that ensure all stakeholders have an
       equal opportunity to contribute, underpinned by a commitment to transparency
       and meaningful public representation at every stage."
@@ -1965,8 +1965,7 @@ specification:
       "Federations may be long-standing and stable or short lived and project
       based the processes should reflect the impact of a member TRE joining/leaving.
       The federation may include passive or default processes, like removal through
-      inactivity or non-compliance.\n\nThese processes should include the credential
-      management /revocation etc."
+      inactivity or non-compliance.\n\nThese processes should consider access/credential revocation, data and log retention/deletion etc."
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-governance
   - pillar: Federation
@@ -2033,7 +2032,7 @@ specification:
     requirement_index: 5.3.01
     statement: The federation must maintain a register of "Safe Projects"
     guidance:
-      "The project register should be accessible programmatically (E.g. via API) by all member TREs, good practice to make it available to public.
+      "The project register should be accessible programmatically (E.g. via API) by all member TREs, good practice to make it available to public with descriptions in plain English.
       See HDRUK for recommendations for a data use registry standard"
     importance: Mandatory
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-study-management
@@ -2120,7 +2119,7 @@ specification:
     statement: The Federation should provide searchable catalogue(s) of metadata
       describing data assets across federation members
     guidance:
-      "Metadata catalogues describing data across a federation should support
+      "Catalogues describing data, using an agreed metadata standard, across a federation should support
       semantic searches across diverse data types.\nThe Federation should agree a
       minimum level of metadata completeness."
     importance: Recommended
@@ -2129,9 +2128,11 @@ specification:
     capability: Federation Financial Management
     capability_index: "5.7"
     requirement_index: 5.7.01
-    statement: The federation should agree a pricing model for federation
+    statement:
+      The federation should agree a transparent pricing framework for federation
       projects.
-    guidance: A consistent charging mechanism prevents differential charging and
+    guidance:
+      A consistent, transparent charging mechanism implemented to prevent differential charging and
       competition between member TREs for similar data.
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-federation-financial-management


### PR DESCRIPTION
Packaged together some minor changes so we can focus on substantive changes when the SATRE team meets.


5.1.02 (Federation governance structure): Added "and external oversight" to the list of example stakeholder parties; strengthened language around equal opportunity to contribute; reworded for clarity ("best-practice decision-making processes").
5.1.03 (Roles and responsibilities): Simplified "a RACI matrix" to "RACI" to avoid implying a single format.
5.1.04 (Audit and rules): Changed "its members" to "other members" for clarity.
5.1.05 (Rules and SOPs): Replaced "rules and SOPs" with "processes" in one instance for consistency; removed ambiguous "regardless" (missing conjunction).
5.1.06 (Joining and leaving): Replaced vague "credential management / revocation etc." with more specific "access/credential revocation, data and log retention/deletion etc."
5.3.02 (Project register): Added "with descriptions in plain English" — reflecting the public accessibility intent raised in discussion.
5.6.02 (Metadata catalogue): Reworded to clarify that catalogues should use "an agreed metadata standard."
5.7.01 (Pricing model): Renamed to "transparent pricing framework" throughout; added "transparent" to guidance to reinforce the principle.

resolves #509 #513 #523  #525 #526  