### PR TITLE
3.1.20: new requirement on metadata disclosure risk

### DIFF
--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1484,7 +1484,7 @@ specification:
     capability_index: "3.1"
     requirement_index: 3.1.20
     statement: Metadata should be checked for disclosure risk at the point of data upload
-    guidance: Metadata can be informative about data subjects even if no figures are produced (eg names of data collection points identify location of respondents). As this is a dataset risk, not a research risk, this should be checked once at the time the dataset is added to the TRE.
+    guidance: Metadata can be informative about data subjects even if no figures are produced (e.g. names of data collection points identify location of respondents). As this is a dataset risk, not a research risk, this should be checked once when the dataset is added to the TRE.
     importance: Recommended
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-b039ff3b59d047f0b6e9bd95ec5f7c6f
   - pillar: Data Management

--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1480,6 +1480,14 @@ specification:
     importance: Optional
     architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-52fc27d7c99f4324a6e922fbb455628e
   - pillar: Data Management
+    capability: Data Lifecycle Management
+    capability_index: "3.1"
+    requirement_index: 3.1.20
+    statement: Metadata should be checked for disclosure risk at the point of data upload
+    guidance: Metadata can be informative about data subjects even if no figures are produced (eg names of data collection points identify location of respondents). As this is a dataset risk, not a research risk, this should be checked once at the time the dataset is added to the TRE.
+    importance: Recommended
+    architecture_url: https://satre-archimate.readthedocs.io/en/latest/?view=id-b039ff3b59d047f0b6e9bd95ec5f7c6f
+  - pillar: Data Management
     capability: Identity and Access Management
     capability_index: "3.2"
     requirement_index: 3.2.01


### PR DESCRIPTION
Closes https://github.com/sa-tre/satre-specification/issues/340

The original proposal is to add this to the Research Metadata section
https://satre-specification.readthedocs.io/en/v1.1.1/pillars/data_management.html#research-meta-data

But I think it fits better under 3.1 data lifecycle management instead- happy to move it though.
