### PR TITLE
This was causing an extra pillar to appear

### DIFF
--- a/docs/source/spec/specification.yaml
+++ b/docs/source/spec/specification.yaml
@@ -1021,7 +1021,7 @@ specification:
       assess threats.\n\nInformation on threat models here:\nhttps://owasp.org/www-community/Threat_Modeling"
     importance: Optional
     architecture_url: https://satre-archimate.readthedocs.io/en/v2.0.0/?view=id-99ff165db6264d4ba94b36d9d014f9f4
-  - pillar: Computing technology and Information Security
+  - pillar: Computing Technology and Information Security
     capability: Information Security
     capability_index: "2.5"
     requirement_index: 2.5.03


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.


### :arrow_heading_up: Summary

This was introduced because a cross over of changes. corrected the pillar ref for 2.5.03
