### PR TITLE
Update README again, add code of conduct back

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers of the SATRE project pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery and unwelcome sexual attention or advances
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or electronic address, without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Please report incidents to the Senior Community Manager Arron Lacey (alacey@turing.ac.uk) who will involve project members Hari Sood, Simon Li and Christian Cole. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 1.4, available at [https://www.contributor-covenant.org/version/1/4/code-of-conduct.html](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Please report incidents to the Senior Community Manager Arron Lacey (alacey@turing.ac.uk) who will involve project members Hari Sood, Simon Li and Christian Cole. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Please report incidents to the Project lead Christian Cole. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ You can also reach out directly to any of our [technical contacts](#technical-co
 
 ### Other Ways to Contribute
 
-- [Join the UKTRE Community](https://www.uktre.org/en/latest/background/index.html)
+[Join the UKTRE Community](https://www.uktre.org/)
+
+- [Slack workspace](https://join.slack.com/t/uktrecommunity/shared_invite/zt-2gep86apc-QMLyIdrC2oIIsxTRzLxUqA)
+- [Mailing List](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=UK-TRE-COMM&A=1)
 
 ## Key Features
 
@@ -34,10 +37,10 @@ You can also reach out directly to any of our [technical contacts](#technical-co
 
 The specification is generated from `docs/source/spec/specification.yaml` using a custom Sphinx extension (`yamlspec.py`). The specification is organized into four pillars:
 
-- Information governance
-- Computing technology and Information Security
-- Data management
-- Supporting capabilities
+- Information Governance
+- Computing Technology and Information Security
+- Data Management
+- Supporting Capabilities
 - Federation (extension for federated TREs)
 
 ## Building the Documentation Locally
@@ -82,19 +85,13 @@ To update the specification content:
 1. Edit the YAML specification file: `docs/source/spec/specification.yaml`
 2. Rebuild the documentation
 
-## Community
-
-- **Slack**: [Join the RSE TRE Working Group](https://ukrse.slack.com/archives/rse-tre-wg)
-- **Mailing List**: [RSE TRE Community](https://www.jiscmail.ac.uk/cgi-bin/wa-jisc.exe?SUBED1=RSE-TRE-COMM&A=1)
-- **Contact List**: [Sign up for updates](https://forms.office.com/e/FuFyNGx3hw)
-
 ## Code of Conduct
 
 The SATRE project is committed to fostering an inclusive, equitable, and respectful environment for all participants. Please review our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## License
 
-The content of this repository is licensed under the [Creative Commons License](LICENSE.md).
+The content of this repository is licensed under the [Creative Commons Attribution 4.0 International Public License](LICENSE.md).
 
 ## Technical Contacts
 
@@ -107,4 +104,5 @@ For technical questions about this repository:
 
 ## Acknowledgements
 
-This project is supported by UKRI via the DARE UK Phase 1 driver projects programme. We are grateful to all [DARE Phase 1 contributors](CONTRIBUTORS.md) who have helped develop the SATRE specification.
+Version 1 of SATRE was supported by UKRI via the DARE UK Phase 1 driver projects programme.
+Version 2 was created as part of the [DARE UK TREvolution](https://dareuk.org.uk/trevolution/) programme.


### PR DESCRIPTION
Noticed some other bits of the README were out of date, and the CoC was accidentally removed as part of the reorganisation