### PR TITLE
https://www.iso.org/standard/27001 is blocked in CI linkcheck

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ linkcheck_ignore = [
     "https://www.dundee.ac.uk/hic",
     "https://eosc-entrust.eu/architecture",
     "https://satre-specification.readthedocs.io/en/v2.0.0/",
+    "https://www.iso.org/standard/27001",
 ]
 
 # Exclude archive directory from linkcheck


### PR DESCRIPTION
## :white_check_mark: Checklist

- [x] This pull request has a meaningful title.
- [ ] If your changes are not yet ready to merge, you have marked this pull request as a **draft** pull request.

## :ballot_box_with_check: Maintainers' checklist

<!--
This checklist is for project maintainers to use after the pull request is submitted.
Feel free to leave these empty.
-->

- [x] This pull request has had the appropriate labels assigned
- [x] This pull request has been added to the SATRE backlog project board
- [ ] This pull request has been assigned to one or more maintainers

### :arrow_heading_up: Summary

<!--
Please explain what your pull request does here.
-->

### :closed_umbrella: Related issues

<!--
If your pull request will close any open issues add `Closes #<issue number>` here.
Also not any issues your pull request relates to, for example `Contributes to #<issue number>`.
-->

### :raising_hand: Acknowledging contributors

<!-- Please tick one of these boxes and list any contributors who should be recognised.-->

- [ ] All contributors to this pull request are already named in the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file.
- [ ] The following people should be added to the [table of contributors](https://github.com/sa-tre/satre-specification#contributors) in the README file: <!-- replace this text with the GitHub IDs of any new contributors -->
